### PR TITLE
Add drawer sidebar scene

### DIFF
--- a/TwidereSDK/Sources/CoreDataStack/CoreDataStack.swift
+++ b/TwidereSDK/Sources/CoreDataStack/CoreDataStack.swift
@@ -64,7 +64,8 @@ public final class CoreDataStack {
         
         // Observe Core Data remote change notifications on the queue where the changes were made.
         NotificationCenter.default.publisher(for: .NSPersistentStoreRemoteChange)
-            .sink { notification in
+            .sink { [weak self] notification in
+                guard let self = self else { return }
                 Task {
                     do {
                         try await self.processRemoteStoreChange()

--- a/TwidereSDK/Sources/TwidereCore/Protocol/TextStyleConfigurable.swift
+++ b/TwidereSDK/Sources/TwidereCore/Protocol/TextStyleConfigurable.swift
@@ -34,6 +34,8 @@ public enum TextStyle {
     case profileFieldValue
     case hashtagTitle
     case hashtagDescription
+    case sidebarAuthorName
+    case sidebarAuthorUsername
     
     case custom(Configuration)
     public struct Configuration {
@@ -69,6 +71,8 @@ extension TextStyle {
         case .profileFieldValue:        return 0
         case .hashtagTitle:             return 1
         case .hashtagDescription:       return 1
+        case .sidebarAuthorName:        return 1
+        case .sidebarAuthorUsername:    return 1
         case .custom:                   return 1
         }
     }
@@ -109,6 +113,10 @@ extension TextStyle {
             return .preferredFont(forTextStyle: .headline)
         case .hashtagDescription:
             return .preferredFont(forTextStyle: .subheadline)
+        case .sidebarAuthorName:
+            return .systemFont(ofSize: 16, weight: .regular)
+        case .sidebarAuthorUsername:
+            return .systemFont(ofSize: 14, weight: .regular)
         case .custom(let configuration):
             return configuration.font
         }
@@ -147,6 +155,10 @@ extension TextStyle {
         case .hashtagTitle:
             return .label
         case .hashtagDescription:
+            return .secondaryLabel
+        case .sidebarAuthorName:
+            return .label
+        case .sidebarAuthorUsername:
             return .secondaryLabel
         case .custom(let configuration):
             return configuration.textColor
@@ -200,6 +212,10 @@ extension MetaLabel: TextStyleConfigurable {
         case .hashtagTitle:
             break
         case .hashtagDescription:
+            break
+        case .sidebarAuthorName:
+            break
+        case .sidebarAuthorUsername:
             break
         case .custom:
             break

--- a/TwidereSDK/Sources/TwidereCore/Service/KeyboardResponderService.swift
+++ b/TwidereSDK/Sources/TwidereCore/Service/KeyboardResponderService.swift
@@ -23,21 +23,24 @@ public final class KeyboardResponderService {
     
     private init() {
         NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification, object: nil)
-            .sink { notification in
+            .sink { [weak self] notification in
+                guard let self = self else { return }
                 self.isShow.value = true
                 self.updateInternalStatus(notification: notification)
             }
             .store(in: &disposeBag)
         
         NotificationCenter.default.publisher(for: UIResponder.keyboardDidHideNotification, object: nil)
-            .sink { notification in
+            .sink { [weak self] notification in
+                guard let self = self else { return }
                 self.isShow.value = false
                 self.updateInternalStatus(notification: notification)
             }
             .store(in: &disposeBag)
         
         NotificationCenter.default.publisher(for: UIResponder.keyboardDidChangeFrameNotification, object: nil)
-            .sink { notification in
+            .sink { [weak self] notification in
+                guard let self = self else { return }
                 self.updateInternalStatus(notification: notification)
             }
             .store(in: &disposeBag)

--- a/TwidereSDK/Sources/TwidereUI/Container/ProfileAvatarView.swift
+++ b/TwidereSDK/Sources/TwidereUI/Container/ProfileAvatarView.swift
@@ -122,9 +122,9 @@ extension ProfileAvatarView {
         self.avatarButtonHeightLayoutConstraint.constant = dimension
         
         let scale = dimension / ProfileAvatarView.primitiveAvatarButtonSize.width
-        let badgeDimention = ProfileAvatarView.primitiveBadgeImageViewSize.width * scale
-        self.badgeImageViewWidthLayoutConstraint.constant = badgeDimention
-        self.badgeImageViewHeightLayoutConstraint.constant = badgeDimention
+        let badgeDimension = ProfileAvatarView.primitiveBadgeImageViewSize.width * scale
+        self.badgeImageViewWidthLayoutConstraint.constant = badgeDimension
+        self.badgeImageViewHeightLayoutConstraint.constant = badgeDimension
         
         self.setNeedsLayout()
     }

--- a/TwidereX.xcodeproj/project.pbxproj
+++ b/TwidereX.xcodeproj/project.pbxproj
@@ -213,6 +213,8 @@
 		DBA61AB62552596A006AC169 /* UserMediaTimelineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA61AB52552596A006AC169 /* UserMediaTimelineViewController.swift */; };
 		DBA6B1B725355C1E005FB0B4 /* UIAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA6B1B625355C1E005FB0B4 /* UIAlertController.swift */; };
 		DBA7DD74256B96450008A95A /* UIFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA7DD73256B96450008A95A /* UIFont.swift */; };
+		DBAA898E2758CF01001C273B /* DrawerSidebarHeaderView+ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBAA898D2758CF01001C273B /* DrawerSidebarHeaderView+ViewModel.swift */; };
+		DBAA89902758DFC9001C273B /* AvatarBarButtonItem+ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBAA898F2758DFC9001C273B /* AvatarBarButtonItem+ViewModel.swift */; };
 		DBAF13CF2747BC8E00EDD839 /* TwidereCommon in Frameworks */ = {isa = PBXBuildFile; productRef = DBAF13CE2747BC8E00EDD839 /* TwidereCommon */; };
 		DBAF13D12747BC9E00EDD839 /* TwidereCore in Frameworks */ = {isa = PBXBuildFile; productRef = DBAF13D02747BC9E00EDD839 /* TwidereCore */; };
 		DBAF13D52747BF0F00EDD839 /* CoreDataStack in Frameworks */ = {isa = PBXBuildFile; productRef = DBAF13D42747BF0F00EDD839 /* CoreDataStack */; };
@@ -255,6 +257,13 @@
 		DBCE2E912591A06300926D09 /* UINavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBCE2E902591A06300926D09 /* UINavigationController.swift */; };
 		DBCE2E992591A44000926D09 /* UIViewAnimatingPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBCE2E982591A44000926D09 /* UIViewAnimatingPosition.swift */; };
 		DBCE2EE32593319000926D09 /* AvatarConfigurableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBCE2EE22593319000926D09 /* AvatarConfigurableView.swift */; };
+		DBD0B4972758B57F0015A388 /* DrawerSidebarTransitionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBEFDC91255920060086F268 /* DrawerSidebarTransitionController.swift */; };
+		DBD0B4982758B58F0015A388 /* DrawerSidebarPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFCC46225668B860016698E /* DrawerSidebarPresentationController.swift */; };
+		DBD0B4992758B58F0015A388 /* DrawerSidebarAnimatedTransitioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB761E3E25592AA20050DC01 /* DrawerSidebarAnimatedTransitioning.swift */; };
+		DBD0B49A2758B5A60015A388 /* DrawerSidebarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB761E69255946160050DC01 /* DrawerSidebarViewModel.swift */; };
+		DBD0B49B2758B5A60015A388 /* DrawerSidebarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBEFDC8725591F5C0086F268 /* DrawerSidebarViewController.swift */; };
+		DBD0B49D2758B5F50015A388 /* SidebarSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD0B49C2758B5F50015A388 /* SidebarSection.swift */; };
+		DBD0B4A02758B6010015A388 /* SidebarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD0B49F2758B6010015A388 /* SidebarItem.swift */; };
 		DBD40B852599B9C2006E4ABC /* CombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD40B842599B9C2006E4ABC /* CombineTests.swift */; };
 		DBD98489251CB88A00ED87A1 /* Tabman in Frameworks */ = {isa = PBXBuildFile; productRef = DBD98488251CB88A00ED87A1 /* Tabman */; };
 		DBDA8E2224FCF8A3006750DC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDA8E2124FCF8A3006750DC /* AppDelegate.swift */; };
@@ -717,6 +726,8 @@
 		DBA7DD73256B96450008A95A /* UIFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFont.swift; sourceTree = "<group>"; };
 		DBA9B3A525875B6B00EA14ED /* MentionPickViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MentionPickViewController.swift; sourceTree = "<group>"; };
 		DBA9B3C02587609200EA14ED /* MentionPickViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MentionPickViewModel.swift; sourceTree = "<group>"; };
+		DBAA898D2758CF01001C273B /* DrawerSidebarHeaderView+ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DrawerSidebarHeaderView+ViewModel.swift"; sourceTree = "<group>"; };
+		DBAA898F2758DFC9001C273B /* AvatarBarButtonItem+ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AvatarBarButtonItem+ViewModel.swift"; sourceTree = "<group>"; };
 		DBAC4A6625552A1E00140B23 /* MediaPreviewImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPreviewImageViewModel.swift; sourceTree = "<group>"; };
 		DBB1FEC1269C34FE005BC761 /* AvatarImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarImageView.swift; sourceTree = "<group>"; };
 		DBB1FEC3269C3714005BC761 /* StatusSwiftUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusSwiftUIView.swift; sourceTree = "<group>"; };
@@ -775,6 +786,8 @@
 		DBCE2ED72591FDF000926D09 /* FollowingListViewModel+State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FollowingListViewModel+State.swift"; sourceTree = "<group>"; };
 		DBCE2EE22593319000926D09 /* AvatarConfigurableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarConfigurableView.swift; sourceTree = "<group>"; };
 		DBCE2EE725933B1600926D09 /* SearchUserTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchUserTableViewCell.swift; sourceTree = "<group>"; };
+		DBD0B49C2758B5F50015A388 /* SidebarSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSection.swift; sourceTree = "<group>"; };
+		DBD0B49F2758B6010015A388 /* SidebarItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarItem.swift; sourceTree = "<group>"; };
 		DBD40B842599B9C2006E4ABC /* CombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineTests.swift; sourceTree = "<group>"; };
 		DBD40BEE2599CB89006E4ABC /* FollowerListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowerListViewController.swift; sourceTree = "<group>"; };
 		DBD40C0C2599CD9D006E4ABC /* FollowerListViewController+UserProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FollowerListViewController+UserProvider.swift"; sourceTree = "<group>"; };
@@ -1407,6 +1420,7 @@
 			isa = PBXGroup;
 			children = (
 				DB761E4D255935380050DC01 /* DrawerSidebarHeaderView.swift */,
+				DBAA898D2758CF01001C273B /* DrawerSidebarHeaderView+ViewModel.swift */,
 				DB761E61255942050050DC01 /* DrawerSidebarEntryView.swift */,
 				DB761E5C255940EF0050DC01 /* DrawerSidebarEntryTableViewCell.swift */,
 			);
@@ -1475,6 +1489,7 @@
 				DB8761B42745515F00BA7EE2 /* Notification */,
 				DB8761BA2745515F00BA7EE2 /* CoverFlowStack */,
 				DB8761D12745553A00BA7EE2 /* Media */,
+				DBD0B49E2758B5F70015A388 /* Sidebar */,
 			);
 			path = Msic;
 			sourceTree = "<group>";
@@ -1728,6 +1743,7 @@
 			children = (
 				DB915405254FC8CE00613473 /* FollowActionButton.swift */,
 				DBC747E0259DBD5400787EEF /* AvatarBarButtonItem.swift */,
+				DBAA898F2758DFC9001C273B /* AvatarBarButtonItem+ViewModel.swift */,
 			);
 			path = Button;
 			sourceTree = "<group>";
@@ -1910,6 +1926,15 @@
 				DB0D0AC725944FF2007A23C8 /* FollowingListViewController+UserProvider.swift */,
 			);
 			path = FollowingList;
+			sourceTree = "<group>";
+		};
+		DBD0B49E2758B5F70015A388 /* Sidebar */ = {
+			isa = PBXGroup;
+			children = (
+				DBD0B49C2758B5F50015A388 /* SidebarSection.swift */,
+				DBD0B49F2758B6010015A388 /* SidebarItem.swift */,
+			);
+			path = Sidebar;
 			sourceTree = "<group>";
 		};
 		DBD40BF62599CB93006E4ABC /* FollowerList */ = {
@@ -2900,6 +2925,7 @@
 				DBCB402E255B670C00DD8D8F /* AccountListViewController.swift in Sources */,
 				DBDA8E9824FE075E006750DC /* MainTabBarController.swift in Sources */,
 				DBCB408A255D8C2B00DD8D8F /* SafariActivity.swift in Sources */,
+				DBD0B4992758B58F0015A388 /* DrawerSidebarAnimatedTransitioning.swift in Sources */,
 				DB02C76D27350D71007EA0BF /* SearchHashtagViewController.swift in Sources */,
 				DB2C873E274F4B7D00CE0398 /* DeveloperViewController.swift in Sources */,
 				DBFA4A2025A5924C00D51703 /* HomeTimelineViewModel+Diffable.swift in Sources */,
@@ -2926,6 +2952,7 @@
 				DB01091A26E60693005F67D7 /* ContentOffsetAdjustableTimelineViewControllerDelegate.swift in Sources */,
 				DBCB4060255CAC0300DD8D8F /* TwitterAuthenticationController.swift in Sources */,
 				DB5632B426DDE3F300FC893F /* StatusThreadViewModel+LoadThreadState.swift in Sources */,
+				DBD0B49D2758B5F50015A388 /* SidebarSection.swift in Sources */,
 				DB94887D2599F70600C3E111 /* TimelineHeaderTableViewCell.swift in Sources */,
 				DBE71B7F26B7D68500DFAB8E /* StubTimelineCollectionViewCell.swift in Sources */,
 				DB213FA627392ABC009ABD74 /* HashtagTimelineViewController.swift in Sources */,
@@ -2963,12 +2990,14 @@
 				DB44A56226C4FEAB004C8B78 /* WelcomeViewModel.swift in Sources */,
 				DBC8E04B2576337F00401E20 /* DisposeBagCollectable.swift in Sources */,
 				DB71C7C6271D304900BE3819 /* UserLikeTimelineViewController+DataSourceProvider.swift in Sources */,
+				DBAA898E2758CF01001C273B /* DrawerSidebarHeaderView+ViewModel.swift in Sources */,
 				DB02C77927352217007EA0BF /* SearchHashtagViewModel+Diffable.swift in Sources */,
 				DB262A4327229BE700D18EF3 /* SearchTimelineViewController.swift in Sources */,
 				DBF63A38259D7CCB009E12C8 /* CornerSmoothPreviewViewController.swift in Sources */,
 				DB02C77527351DA2007EA0BF /* HashtagTableViewCell+ViewModel.swift in Sources */,
 				DB86433C26E898C5000C9879 /* DataSourceFacade+Like.swift in Sources */,
 				DB914C4A26C3AC7C00E85F1A /* ContentOffsetFixedCollectionView.swift in Sources */,
+				DBD0B4A02758B6010015A388 /* SidebarItem.swift in Sources */,
 				DB262A502726938600D18EF3 /* SearchMediaViewModel+State.swift in Sources */,
 				DB969A2F252490090053CB31 /* UserTimelineViewModel+State.swift in Sources */,
 				DB42410E26C3E4BF00B6C5F8 /* WelcomeViewController.swift in Sources */,
@@ -2978,6 +3007,7 @@
 				DB2C8742274F4B7D00CE0398 /* AboutViewController.swift in Sources */,
 				DB5FD9B326D8D94600CF5439 /* StatusTableViewCell+ViewModel.swift in Sources */,
 				DBC747E1259DBD5400787EEF /* AvatarBarButtonItem.swift in Sources */,
+				DBD0B49A2758B5A60015A388 /* DrawerSidebarViewModel.swift in Sources */,
 				DB5632A726DCC84C00FC893F /* DataSourceProvider+UITableViewDelegate.swift in Sources */,
 				DBB47DAD26EB440C001590F7 /* ProfileFieldCollectionViewCell.swift in Sources */,
 				DB3B905F26E8A9650010F64C /* StatusThreadViewController+DataSourceProvider.swift in Sources */,
@@ -2988,6 +3018,7 @@
 				DB43488D251DFF0F005B599F /* ProfileBannerStatusItemView.swift in Sources */,
 				DBE76D1E2500E65D00DEB0FC /* HomeTimelineViewModel.swift in Sources */,
 				DBDAF240274F530300050319 /* AppContext.swift in Sources */,
+				DBD0B4982758B58F0015A388 /* DrawerSidebarPresentationController.swift in Sources */,
 				DB5A2288255B9155006CA5B2 /* AccountListViewModel+Diffable.swift in Sources */,
 				DB12BEE727329F55002AA635 /* SearchUserViewController+DataSourceProvider.swift in Sources */,
 				DB42411426C3E55200B6C5F8 /* WelcomeView.swift in Sources */,
@@ -2999,6 +3030,7 @@
 				DBCB4047255B683B00DD8D8F /* AccountListTableViewCell.swift in Sources */,
 				DBF639FC259B333A009E12C8 /* EmptyStateView.swift in Sources */,
 				DBFCC44725667C620016698E /* UILabel.swift in Sources */,
+				DBAA89902758DFC9001C273B /* AvatarBarButtonItem+ViewModel.swift in Sources */,
 				DB262A4E2726928F00D18EF3 /* SearchMediaViewModel.swift in Sources */,
 				DB9EC4EA255A6BC7005403AA /* TwitterAccountUnlockViewController.swift in Sources */,
 				DB71C7D1271EB09A00BE3819 /* DataSourceFacade+Friendship.swift in Sources */,
@@ -3025,6 +3057,7 @@
 				DB5632BC26DF503800FC893F /* TwitterStatusThreadLeafViewModel.swift in Sources */,
 				DB51DC1A2715581E00A0D8FB /* ProfileDashboardView.swift in Sources */,
 				DB2C873D274F4B7D00CE0398 /* DeveloperViewModel.swift in Sources */,
+				DBD0B4972758B57F0015A388 /* DrawerSidebarTransitionController.swift in Sources */,
 				DB8761C7274552FF00BA7EE2 /* NotificationSection.swift in Sources */,
 				DB5632B026DCED1300FC893F /* StatusThreadRootTableViewCell.swift in Sources */,
 				DB8761C4274552FB00BA7EE2 /* HashtagData.swift in Sources */,
@@ -3076,6 +3109,7 @@
 				DB8301F7273CED0400BF5224 /* NotificationTimelineViewController.swift in Sources */,
 				DB5632AD26DCE93900FC893F /* StatusThreadViewModel+Diffable.swift in Sources */,
 				DBF639F7259B1728009E12C8 /* TimelineHeaderCollectionViewCell.swift in Sources */,
+				DBD0B49B2758B5A60015A388 /* DrawerSidebarViewController.swift in Sources */,
 				DB51DC222715786700A0D8FB /* StatusListFetchViewModel.swift in Sources */,
 				DB2C873F274F4B7D00CE0398 /* DisplayPreferenceViewController.swift in Sources */,
 				DB7274EF273BB25200577D95 /* NotificationViewController.swift in Sources */,

--- a/TwidereX.xcodeproj/project.pbxproj
+++ b/TwidereX.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 		DBA7DD74256B96450008A95A /* UIFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBA7DD73256B96450008A95A /* UIFont.swift */; };
 		DBAA898E2758CF01001C273B /* DrawerSidebarHeaderView+ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBAA898D2758CF01001C273B /* DrawerSidebarHeaderView+ViewModel.swift */; };
 		DBAA89902758DFC9001C273B /* AvatarBarButtonItem+ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBAA898F2758DFC9001C273B /* AvatarBarButtonItem+ViewModel.swift */; };
+		DBAA89922758EF12001C273B /* DrawerSidebarViewModel+Diffable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBAA89912758EF12001C273B /* DrawerSidebarViewModel+Diffable.swift */; };
 		DBAF13CF2747BC8E00EDD839 /* TwidereCommon in Frameworks */ = {isa = PBXBuildFile; productRef = DBAF13CE2747BC8E00EDD839 /* TwidereCommon */; };
 		DBAF13D12747BC9E00EDD839 /* TwidereCore in Frameworks */ = {isa = PBXBuildFile; productRef = DBAF13D02747BC9E00EDD839 /* TwidereCore */; };
 		DBAF13D52747BF0F00EDD839 /* CoreDataStack in Frameworks */ = {isa = PBXBuildFile; productRef = DBAF13D42747BF0F00EDD839 /* CoreDataStack */; };
@@ -728,6 +729,7 @@
 		DBA9B3C02587609200EA14ED /* MentionPickViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MentionPickViewModel.swift; sourceTree = "<group>"; };
 		DBAA898D2758CF01001C273B /* DrawerSidebarHeaderView+ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DrawerSidebarHeaderView+ViewModel.swift"; sourceTree = "<group>"; };
 		DBAA898F2758DFC9001C273B /* AvatarBarButtonItem+ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AvatarBarButtonItem+ViewModel.swift"; sourceTree = "<group>"; };
+		DBAA89912758EF12001C273B /* DrawerSidebarViewModel+Diffable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DrawerSidebarViewModel+Diffable.swift"; sourceTree = "<group>"; };
 		DBAC4A6625552A1E00140B23 /* MediaPreviewImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPreviewImageViewModel.swift; sourceTree = "<group>"; };
 		DBB1FEC1269C34FE005BC761 /* AvatarImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarImageView.swift; sourceTree = "<group>"; };
 		DBB1FEC3269C3714005BC761 /* StatusSwiftUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusSwiftUIView.swift; sourceTree = "<group>"; };
@@ -2231,6 +2233,7 @@
 				DB761E522559353B0050DC01 /* View */,
 				DBEFDC8725591F5C0086F268 /* DrawerSidebarViewController.swift */,
 				DB761E69255946160050DC01 /* DrawerSidebarViewModel.swift */,
+				DBAA89912758EF12001C273B /* DrawerSidebarViewModel+Diffable.swift */,
 			);
 			path = Drawer;
 			sourceTree = "<group>";
@@ -3107,6 +3110,7 @@
 				DBC747D9259DA07C00787EEF /* ListTableViewCell.swift in Sources */,
 				DB7E23032552A6D100551314 /* UserLikeTimelineViewModel+Diffable.swift in Sources */,
 				DB8301F7273CED0400BF5224 /* NotificationTimelineViewController.swift in Sources */,
+				DBAA89922758EF12001C273B /* DrawerSidebarViewModel+Diffable.swift in Sources */,
 				DB5632AD26DCE93900FC893F /* StatusThreadViewModel+Diffable.swift in Sources */,
 				DBF639F7259B1728009E12C8 /* TimelineHeaderCollectionViewCell.swift in Sources */,
 				DBD0B49B2758B5A60015A388 /* DrawerSidebarViewController.swift in Sources */,

--- a/TwidereX/Coordinator/SceneCoordinator.swift
+++ b/TwidereX/Coordinator/SceneCoordinator.swift
@@ -53,19 +53,21 @@ extension SceneCoordinator {
         
         // Status
         case statusThread(viewModel: StatusThreadViewModel)
+        case compose(viewModel: ComposeViewModel, contentViewModel: ComposeContentViewModel)
         
         // Hashtag
         case hashtagTimeline(viewModel: HashtagTimelineViewModel)
         
+        // Sidebar
+        case drawerSidebar(viewModel: DrawerSidebarViewModel)
+
         // TODO:
-        case compose(viewModel: ComposeViewModel, contentViewModel: ComposeContentViewModel)
 //        case mentionPick(viewModel: MentionPickViewModel, delegate: MentionPickViewControllerDelegate)
         // case tweetConversation(viewModel: TweetConversationViewModel)
 //        case searchDetail(viewModel: SearchDetailViewModel)
         case profile(viewModel: ProfileViewModel)
 //        case friendshipList(viewModel: FriendshipListViewModel)
 //        case mediaPreview(viewModel: MediaPreviewViewModel)
-//        case drawerSidebar
 
         case setting
         case displayPreference
@@ -238,8 +240,10 @@ private extension SceneCoordinator {
 //            let _viewController = MediaPreviewViewController()
 //            _viewController.viewModel = viewModel
 //            viewController = _viewController
-//        case .drawerSidebar:
-//            viewController = DrawerSidebarViewController()
+        case .drawerSidebar(let viewModel):
+            let _viewController = DrawerSidebarViewController()
+            _viewController.viewModel = viewModel
+            viewController = _viewController
         case .setting:
             viewController = SettingListViewController()
         case .displayPreference:

--- a/TwidereX/Diffable/Msic/Sidebar/SidebarItem.swift
+++ b/TwidereX/Diffable/Msic/Sidebar/SidebarItem.swift
@@ -1,0 +1,46 @@
+//
+//  SidebarItem.swift
+//  TwidereX
+//
+//  Created by MainasuK on 2021-12-2.
+//  Copyright © 2021 Twidere. All rights reserved.
+//
+
+import UIKit
+import TwidereAsset
+import TwidereLocalization
+
+enum SidebarItem: Hashable {
+    case messages
+    case likes
+    case lists
+    case trends
+    case drafts
+    case settings
+}
+
+extension SidebarItem {
+    
+    var title: String {
+        switch self {
+        case .messages:     return L10n.Scene.Messages.title
+        case .likes:        return L10n.Scene.Likes.title
+        case .lists:        return L10n.Scene.Lists.title
+        case .trends:       return L10n.Scene.Trends.title
+        case .drafts:       return L10n.Scene.Drafts.title
+        case .settings:     return L10n.Scene.Settings.title
+        }
+    }
+    
+    var image: UIImage {
+        switch self {
+        case .messages:     return Asset.Communication.mail.image.withRenderingMode(.alwaysTemplate)
+        case .likes:        return Asset.Health.heart.image.withRenderingMode(.alwaysTemplate)
+        case .lists:        return Asset.ObjectTools.bookmarks.image.withRenderingMode(.alwaysTemplate)
+        case .trends:       return Asset.Arrows.trendingUp.image.withRenderingMode(.alwaysTemplate)
+        case .drafts:       return Asset.ObjectTools.note.image.withRenderingMode(.alwaysTemplate)
+        case .settings:     return Asset.Editing.sliderHorizontal3.image.withRenderingMode(.alwaysTemplate)
+        }
+    }
+    
+}

--- a/TwidereX/Diffable/Msic/Sidebar/SidebarSection.swift
+++ b/TwidereX/Diffable/Msic/Sidebar/SidebarSection.swift
@@ -1,0 +1,13 @@
+//
+//  SidebarSection.swift
+//  TwidereX
+//
+//  Created by MainasuK on 2021-12-2.
+//  Copyright © 2021 Twidere. All rights reserved.
+//
+
+import Foundation
+
+enum SidebarSection: Equatable, Hashable {
+    case main
+}

--- a/TwidereX/Diffable/User/UserSection.swift
+++ b/TwidereX/Diffable/User/UserSection.swift
@@ -18,7 +18,7 @@ enum UserSection {
 extension UserSection {
     
     struct Configuration {
-        let userTableViewCellDelegate: UserTableViewCellDelegate?
+        weak var userTableViewCellDelegate: UserTableViewCellDelegate?
     }
     
     static func diffableDataSource(

--- a/TwidereX/Scene/HomeTimeline/HomeTimelineViewController+DebugAction.swift
+++ b/TwidereX/Scene/HomeTimeline/HomeTimelineViewController+DebugAction.swift
@@ -104,7 +104,8 @@ extension HomeTimelineViewController {
                     discoverabilityTitle: nil,
                     attributes: [],
                     state: .off)
-                { action in
+                { [weak self] action in
+                    guard let self = self else { return }
                     self.showNotificationBanner(action, style: style)
                 }
             }
@@ -191,6 +192,10 @@ extension HomeTimelineViewController {
                 UIAction(title: "Reload TableView", image: nil, attributes: [], handler: { [weak self] action in
                     guard let self = self else { return }
                     self.reloadTableView(action)
+                }),
+                UIAction(title: "Reload App", image: nil, attributes: [], handler: { [weak self] action in
+                    guard let self = self else { return }
+                    self.coordinator.setup()
                 }),
             ]
         )

--- a/TwidereX/Scene/HomeTimeline/HomeTimelineViewController.swift
+++ b/TwidereX/Scene/HomeTimeline/HomeTimelineViewController.swift
@@ -34,14 +34,14 @@ final class HomeTimelineViewController: UIViewController, NeedsDependency, Drawe
     var disposeBag = Set<AnyCancellable>()
     private(set) lazy var viewModel = HomeTimelineViewModel(context: context)
     
+    private(set) var drawerSidebarTransitionController: DrawerSidebarTransitionController!
+    let avatarBarButtonItem = AvatarBarButtonItem()
+    
     private(set) lazy var refreshControl: UIRefreshControl = {
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self, action: #selector(HomeTimelineViewController.refreshControlValueChanged(_:)), for: .valueChanged)
         return refreshControl
     }()
-    
-    private(set) var drawerSidebarTransitionController: DrawerSidebarTransitionController!
-    let avatarBarButtonItem = AvatarBarButtonItem()
     
 //    let mediaPreviewTransitionController = MediaPreviewTransitionController()
     

--- a/TwidereX/Scene/HomeTimeline/HomeTimelineViewModel.swift
+++ b/TwidereX/Scene/HomeTimeline/HomeTimelineViewModel.swift
@@ -29,6 +29,7 @@ final class HomeTimelineViewModel: NSObject {
     let context: AppContext
     let fetchedResultsController: FeedFetchedResultsController
     let listBatchFetchViewModel = ListBatchFetchViewModel()
+    let viewDidAppear = CurrentValueSubject<Void, Never>(Void())
     
     // output
     var diffableDataSource: UITableViewDiffableDataSource<StatusSection, StatusItem>?

--- a/TwidereX/Scene/MainTab/MainTabBarController.swift
+++ b/TwidereX/Scene/MainTab/MainTabBarController.swift
@@ -121,7 +121,8 @@ extension MainTabBarController {
 
         context.publisherService.statusPublishResult
             .receive(on: DispatchQueue.main)
-            .sink { result in
+            .sink { [weak self] result in
+                guard let _ = self else { return }
                 switch result {
                 case .success(let result):
                     var config = SwiftMessages.defaultConfig

--- a/TwidereX/Scene/MentionTimeline/MentionTimelineViewController.swift
+++ b/TwidereX/Scene/MentionTimeline/MentionTimelineViewController.swift
@@ -459,18 +459,18 @@ extension MentionTimelineViewController: TimelineMiddleLoaderTableViewCellDelega
     }
 }
 
-// MARK: - AVPlayerViewControllerDelegate
-extension MentionTimelineViewController: AVPlayerViewControllerDelegate {
-    
-    func playerViewController(_ playerViewController: AVPlayerViewController, willBeginFullScreenPresentationWithAnimationCoordinator coordinator: UIViewControllerTransitionCoordinator) {
-        handlePlayerViewController(playerViewController, willBeginFullScreenPresentationWithAnimationCoordinator: coordinator)
-    }
-    
-    func playerViewController(_ playerViewController: AVPlayerViewController, willEndFullScreenPresentationWithAnimationCoordinator coordinator: UIViewControllerTransitionCoordinator) {
-        handlePlayerViewController(playerViewController, willEndFullScreenPresentationWithAnimationCoordinator: coordinator)
-    }
-    
-}
+//// MARK: - AVPlayerViewControllerDelegate
+//extension MentionTimelineViewController: AVPlayerViewControllerDelegate {
+//
+//    func playerViewController(_ playerViewController: AVPlayerViewController, willBeginFullScreenPresentationWithAnimationCoordinator coordinator: UIViewControllerTransitionCoordinator) {
+//        handlePlayerViewController(playerViewController, willBeginFullScreenPresentationWithAnimationCoordinator: coordinator)
+//    }
+//
+//    func playerViewController(_ playerViewController: AVPlayerViewController, willEndFullScreenPresentationWithAnimationCoordinator coordinator: UIViewControllerTransitionCoordinator) {
+//        handlePlayerViewController(playerViewController, willEndFullScreenPresentationWithAnimationCoordinator: coordinator)
+//    }
+//
+//}
 
 // MARK: - TimelinePostTableViewCellDelegate
 //extension MentionTimelineViewController: TimelinePostTableViewCellDelegate {

--- a/TwidereX/Scene/Notification/NotificationViewModel.swift
+++ b/TwidereX/Scene/Notification/NotificationViewModel.swift
@@ -18,7 +18,7 @@ final class NotificationViewModel {
     let context: AppContext
     let _coordinator: SceneCoordinator  // only use for `setup`
     @Published var selectedScope: Scope? = nil
-
+    let viewDidAppear = CurrentValueSubject<Void, Never>(Void())
     
     // output
     @Published var scopes: [Scope] = []

--- a/TwidereX/Scene/Profile/Header/View/ProfileDashboardView.swift
+++ b/TwidereX/Scene/Profile/Header/View/ProfileDashboardView.swift
@@ -11,9 +11,9 @@ import UIKit
 import Combine
 
 protocol ProfileDashboardViewDelegate: AnyObject {
-    func profileDashboardView(_ view: ProfileDashboardView, followingMeterViewDidPressed meterView: ProfileDashboardMeterView)
-    func profileDashboardView(_ view: ProfileDashboardView, followersMeterViewDidPressed meterView: ProfileDashboardMeterView)
-    func profileDashboardView(_ view: ProfileDashboardView, listedMeterViewDidPressed meterView: ProfileDashboardMeterView)
+    func profileDashboardView(_ dashboardView: ProfileDashboardView, followingMeterViewDidPressed meterView: ProfileDashboardMeterView)
+    func profileDashboardView(_ dashboardView: ProfileDashboardView, followersMeterViewDidPressed meterView: ProfileDashboardMeterView)
+    func profileDashboardView(_ dashboardView: ProfileDashboardView, listedMeterViewDidPressed meterView: ProfileDashboardMeterView)
 }
 
 final class ProfileDashboardView: UIView {
@@ -26,6 +26,7 @@ final class ProfileDashboardView: UIView {
     // Mastodon
     // following | follower
     
+    @Published var isAllowAdaptiveLayout = true
     
     let followingMeterView = ProfileDashboardMeterView()
     let separatorLine1 = SeparatorLineView()
@@ -92,32 +93,37 @@ extension ProfileDashboardView {
             statusItemView.addGestureRecognizer(tapGestureRecognizer)
         }
         
-        UIContentSizeCategory.publisher
-            .sink { [weak self] category in
-                guard let self = self else { return }
-                if category >= .accessibilityLarge {
-                    containerStackView.axis = .vertical
-                    containerStackView.spacing = 10
-                    containerStackView.alignment = .leading // set leading
-                    meterViews.forEach { meterView in
-                        meterView.container.axis = .horizontal
-                        meterView.container.distribution = .fill
-                    }
-                    self.separatorLine1.alpha = 0
-                    self.separatorLine2.alpha = 0
-                } else {
-                    containerStackView.axis = .horizontal
-                    containerStackView.spacing = 0
-                    containerStackView.alignment = .fill    // restore default
-                    meterViews.forEach { meterView in
-                        meterView.container.axis = .vertical
-                        meterView.container.distribution = .fillEqually
-                    }
-                    self.separatorLine1.alpha = 1
-                    self.separatorLine2.alpha = 1
+        Publishers.CombineLatest(
+            UIContentSizeCategory.publisher,
+            $isAllowAdaptiveLayout
+        )
+        .sink { [weak self] category, isAllowAdaptiveLayout in
+            guard let self = self else { return }
+            
+            if isAllowAdaptiveLayout, category >= .accessibilityLarge {
+                containerStackView.axis = .vertical
+                containerStackView.spacing = 10
+                containerStackView.alignment = .leading // set leading
+                meterViews.forEach { meterView in
+                    meterView.container.axis = .horizontal
+                    meterView.container.distribution = .fill
                 }
+                self.separatorLine1.alpha = 0
+                self.separatorLine2.alpha = 0
+            } else {
+                containerStackView.axis = .horizontal
+                containerStackView.spacing = 0
+                containerStackView.alignment = .fill    // restore default
+                meterViews.forEach { meterView in
+                    meterView.container.axis = .vertical
+                    meterView.container.distribution = .fillEqually
+                }
+                self.separatorLine1.alpha = 1
+                self.separatorLine2.alpha = 1
             }
-            .store(in: &_disposeBag)
+        }
+        .store(in: &_disposeBag)
+        
     }
 }
 

--- a/TwidereX/Scene/Profile/ProfileViewController.swift
+++ b/TwidereX/Scene/Profile/ProfileViewController.swift
@@ -231,7 +231,7 @@ extension ProfileViewController {
         tabBarPagerController.relayScrollView.refreshControl = refreshControl
         refreshControl.addTarget(self, action: #selector(ProfileViewController.refreshControlValueChanged(_:)), for: .valueChanged)
         
-//        drawerSidebarTransitionController = DrawerSidebarTransitionController(drawerSidebarTransitionableViewController: self)
+//        drawerSidebarTransitionController = DrawerSidebarTransitionController(hostViewController: self)
         
 //        let userTimelineViewModel = UserTimelineViewModel(context: context)
 //        viewModel.userIdentifier

--- a/TwidereX/Scene/Profile/ProfileViewController.swift
+++ b/TwidereX/Scene/Profile/ProfileViewController.swift
@@ -14,7 +14,7 @@ import TabBarPager
 import XLPagerTabStrip
 
 // TODO: DrawerSidebarTransitionableViewController
-final class ProfileViewController: UIViewController, NeedsDependency {
+final class ProfileViewController: UIViewController, NeedsDependency, DrawerSidebarTransitionHostViewController {
     
     let logger = Logger(subsystem: "ProfileViewController", category: "ViewController")
     
@@ -24,9 +24,9 @@ final class ProfileViewController: UIViewController, NeedsDependency {
     var disposeBag = Set<AnyCancellable>()
     var viewModel: ProfileViewModel!
     
-//    private(set) var drawerSidebarTransitionController: DrawerSidebarTransitionController!
-    
+    private(set) var drawerSidebarTransitionController: DrawerSidebarTransitionController!
     let avatarBarButtonItem = AvatarBarButtonItem()
+    
     let unmuteMenuBarButtonItem: UIBarButtonItem = {
         let barButtonItem = UIBarButtonItem(image: Asset.ObjectTools.speakerXmark.image.withRenderingMode(.alwaysTemplate), style: .plain, target: nil, action: nil)
         barButtonItem.tintColor = .systemRed
@@ -83,21 +83,6 @@ final class ProfileViewController: UIViewController, NeedsDependency {
         return profilePagingViewController
     }()
     
-//    private(set) lazy var profileSegmentedViewController = ProfileSegmentedViewController()
-    
-//    private(set) lazy var bar: TMBar = {
-//        let bar = TMBarView<TMHorizontalBarLayout, TMTabItemBarButton, TMLineBarIndicator>()
-//        bar.layout.contentMode = .fit
-//        bar.indicator.weight = .custom(value: 2)
-//        bar.backgroundView.style = .flat(color: .systemBackground)
-//        bar.buttons.customize { barItem in
-//            barItem.shrinksImageWhenUnselected = false
-//            barItem.selectedTintColor = Asset.Colors.hightLight.color
-//            barItem.tintColor = .secondaryLabel
-//        }
-//        return bar
-//    }()
-    
     private var contentOffsets: [Int: CGFloat] = [:]
     var currentPostTimelineTableViewContentSizeObservation: NSKeyValueObservation?
     
@@ -112,11 +97,26 @@ extension ProfileViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        drawerSidebarTransitionController = DrawerSidebarTransitionController(hostViewController: self)
+
         view.backgroundColor = .systemBackground
+        
         if navigationController?.viewControllers.first == self {
             navigationItem.leftBarButtonItem = avatarBarButtonItem
+            avatarBarButtonItem.avatarButton.addTarget(self, action: #selector(ProfileViewController.avatarButtonPressed(_:)), for: .touchUpInside)
+            
+            Publishers.CombineLatest(
+                context.authenticationService.activeAuthenticationContext,
+                viewModel.viewDidAppear.eraseToAnyPublisher()
+            )
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] authenticationContext, _ in
+                guard let self = self else { return }
+                let user = authenticationContext?.user(in: self.context.managedObjectContext)
+                self.avatarBarButtonItem.configure(user: user)
+            }
+            .store(in: &disposeBag)
         }
-        avatarBarButtonItem.avatarButton.addTarget(self, action: #selector(ProfileViewController.avatarButtonPressed(_:)), for: .touchUpInside)
         
         unmuteMenuBarButtonItem.target = self
         unmuteMenuBarButtonItem.action = #selector(ProfileViewController.unmuteBarButtonItemPressed(_:))
@@ -528,7 +528,7 @@ extension ProfileViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-//        viewModel.viewDidAppear.send()
+        viewModel.viewDidAppear.send()
         
         // set overlay scroll view initial content size
 //        guard let currentViewController = profileSegmentedViewController.pagingViewController.currentViewController as? ScrollViewContainer else { return }
@@ -545,6 +545,12 @@ extension ProfileViewController {
 
 extension ProfileViewController {
     
+    @objc private func avatarButtonPressed(_ sender: UIButton) {
+        logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public)")
+        let drawerSidebarViewModel = DrawerSidebarViewModel(context: context)
+        coordinator.present(scene: .drawerSidebar(viewModel: drawerSidebarViewModel), from: self, transition: .custom(transitioningDelegate: drawerSidebarTransitionController))
+    }
+    
     @objc private func refreshControlValueChanged(_ sender: UIRefreshControl) {
         os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
         
@@ -560,11 +566,6 @@ extension ProfileViewController {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
             sender.endRefreshing()
         }
-    }
-    
-    @objc private func avatarButtonPressed(_ sender: UIButton) {
-        os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
-//        coordinator.present(scene: .drawerSidebar, from: self, transition: .custom(transitioningDelegate: drawerSidebarTransitionController))
     }
     
     @objc private func unmuteBarButtonItemPressed(_ sender: UIBarButtonItem) {

--- a/TwidereX/Scene/Profile/ProfileViewModel.swift
+++ b/TwidereX/Scene/Profile/ProfileViewModel.swift
@@ -25,7 +25,7 @@ class ProfileViewModel: ObservableObject {
     @Published var user: UserObject?
 //    let twitterUser: CurrentValueSubject<TwitterUser?, Never>
 //    let currentTwitterUser = CurrentValueSubject<TwitterUser?, Never>(nil)
-//    let viewDidAppear = PassthroughSubject<Void, Never>()
+    let viewDidAppear = CurrentValueSubject<Void, Never>(Void())
         
     // output
     @Published var userRecord: UserRecord?

--- a/TwidereX/Scene/Search/Search/SearchViewController.swift
+++ b/TwidereX/Scene/Search/Search/SearchViewController.swift
@@ -91,7 +91,7 @@ extension SearchViewController {
 //        setupSearchBar()
 //        avatarBarButtonItem.avatarButton.addTarget(self, action: #selector(SearchViewController.avatarButtonPressed(_:)), for: .touchUpInside)
 //
-//        drawerSidebarTransitionController = DrawerSidebarTransitionController(drawerSidebarTransitionableViewController: self)
+//        drawerSidebarTransitionController = DrawerSidebarTransitionController(hostViewController: self)
 //
 //        searchBarTapPublisher
 //            .sink { [weak self] _ in

--- a/TwidereX/Scene/Search/Search/SearchViewController.swift
+++ b/TwidereX/Scene/Search/Search/SearchViewController.swift
@@ -9,16 +9,9 @@
 import os.log
 import UIKit
 import Combine
-//import AlamofireImage
-
-//final class HeightFixedSearchBar: UISearchBar {
-//    override var intrinsicContentSize: CGSize {
-//        return CGSize(width: CGFloat.greatestFiniteMagnitude, height: 44)
-//    }
-//}
 
 // DrawerSidebarTransitionableViewController
-final class SearchViewController: UIViewController, NeedsDependency {
+final class SearchViewController: UIViewController, NeedsDependency, DrawerSidebarTransitionHostViewController {
     
     let logger = Logger(subsystem: "SearchViewController", category: "ViewController")
     
@@ -41,20 +34,10 @@ final class SearchViewController: UIViewController, NeedsDependency {
         return searchController
     }()
     
-//    private(set) var drawerSidebarTransitionController: DrawerSidebarTransitionController!
-//    private var searchDetailTransitionController = SearchDetailTransitionController()
+    private(set) var drawerSidebarTransitionController: DrawerSidebarTransitionController!
+    let avatarBarButtonItem = AvatarBarButtonItem()
 
     var disposeBag = Set<AnyCancellable>()
-//    let viewModel = SearchViewModel()
-    
-//    let avatarBarButtonItem = AvatarBarButtonItem()
-
-//    let searchBar: UISearchBar = {
-//        let searchBar = HeightFixedSearchBar()
-//        searchBar.placeholder = L10n.Scene.Search.SearchBar.placeholder
-//        return searchBar
-//    }()
-//    let searchBarTapPublisher = PassthroughSubject<Void, Never>()
     
     deinit {
         os_log("%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
@@ -67,6 +50,9 @@ extension SearchViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        drawerSidebarTransitionController = DrawerSidebarTransitionController(hostViewController: self)
+
+        view.backgroundColor = .systemBackground
         navigationItem.searchController = searchController
         navigationItem.hidesSearchBarWhenScrolling = false
         

--- a/TwidereX/Scene/Share/View/Button/AvatarBarButtonItem+ViewModel.swift
+++ b/TwidereX/Scene/Share/View/Button/AvatarBarButtonItem+ViewModel.swift
@@ -1,0 +1,70 @@
+//
+//  AvatarBarButtonItem+ViewModel.swift
+//  TwidereX
+//
+//  Created by MainasuK on 2021-12-2.
+//  Copyright © 2021 Twidere. All rights reserved.
+//
+
+import UIKit
+import Combine
+import TwidereCore
+import CoreDataStack
+
+extension AvatarBarButtonItem {
+    public class ViewModel: ObservableObject {
+        var configureDisposeBag = Set<AnyCancellable>()
+        var bindDisposeBag = Set<AnyCancellable>()
+        
+        @Published var avatarURL: URL?
+    }
+}
+
+extension AvatarBarButtonItem.ViewModel {
+    func bind(view: AvatarBarButtonItem) {
+        $avatarURL
+            .sink { avatarURL in
+                let configuration = AvatarImageView.Configuration(url: avatarURL)
+                view.avatarButton.avatarImageView.configure(configuration: configuration)
+            }
+            .store(in: &bindDisposeBag)
+    }
+}
+
+extension AvatarBarButtonItem {
+    func configure(user: UserObject?) {
+        switch user {
+        case .twitter(let object):
+            configure(twitterUser: object)
+        case .mastodon(let object):
+            configure(mastodonUser: object)
+        case .none:
+            reset()
+        }
+    }
+
+}
+
+extension AvatarBarButtonItem {
+    
+    func reset() {
+        viewModel.avatarURL = nil
+    }
+    
+    func configure(twitterUser user: TwitterUser) {
+        // avatar
+        user.publisher(for: \.profileImageURL)
+            .map { _ in user.avatarImageURL() }
+            .assign(to: \.avatarURL, on: viewModel)
+            .store(in: &viewModel.configureDisposeBag)
+    }
+    
+    func configure(mastodonUser user: MastodonUser) {
+        // avatar
+        user.publisher(for: \.avatar)
+            .map { avatar in avatar.flatMap { URL(string: $0) } }
+            .assign(to: \.avatarURL, on: viewModel)
+            .store(in: &viewModel.configureDisposeBag)
+    }
+
+}

--- a/TwidereX/Scene/Share/View/Button/AvatarBarButtonItem.swift
+++ b/TwidereX/Scene/Share/View/Button/AvatarBarButtonItem.swift
@@ -7,17 +7,24 @@
 //
 
 import UIKit
+import TwidereUI
 
 public final class AvatarBarButtonItem: UIBarButtonItem {
 
     public static let avatarButtonSize = CGSize(width: 30, height: 30)
+    
+    private(set) lazy var viewModel: ViewModel = {
+        let viewModel = ViewModel()
+        viewModel.bind(view: self)
+        return viewModel
+    }()
 
-    public let avatarButton: UIButton = {
-        let button = UIButton(type: .custom)
+    public let avatarButton: AvatarButton = {
+        let button = AvatarButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            button.widthAnchor.constraint(equalToConstant: avatarButtonSize.width).priority(.defaultHigh),
-            button.heightAnchor.constraint(equalToConstant: avatarButtonSize.height).priority(.defaultHigh),
+            button.widthAnchor.constraint(equalToConstant: avatarButtonSize.width).priority(.required - 1),
+            button.heightAnchor.constraint(equalToConstant: avatarButtonSize.height).priority(.required - 1),
         ])
         return button
     }()

--- a/TwidereX/Scene/Share/ViewModel/ListBatchFetchViewModel.swift
+++ b/TwidereX/Scene/Share/ViewModel/ListBatchFetchViewModel.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 Twidere. All rights reserved.
 //
 
+import os.log
 import Foundation
 import Combine
 import UIKit
@@ -37,10 +38,10 @@ final class ListBatchFetchViewModel {
             guard let self = self else { return }
             guard hasMore else { return }
             guard let scrollView = self.scrollView else { return }
-            
+
             // skip trigger if user interacting
             if scrollView.isDragging || scrollView.isTracking { return }
-            
+
             // send fetch request
             if scrollView.contentSize.height < scrollView.frame.height {
                 self.shouldFetch.send()
@@ -52,13 +53,17 @@ final class ListBatchFetchViewModel {
                 let visibleBottomY = contentOffset.y + frame.height
                 let offset = 2 * frame.height
                 let fetchThrottleOffsetY = contentSize.height - offset
-                
+
                 if visibleBottomY > fetchThrottleOffsetY {
                     self.shouldFetch.send()
                 }
             }
         }
         .store(in: &disposeBag)
+    }
+    
+    deinit {
+        os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s", ((#file as NSString).lastPathComponent), #line, #function)
     }
     
 }

--- a/TwidereX/Scene/Sidebar/Drawer/DrawerSidebarViewController.swift
+++ b/TwidereX/Scene/Sidebar/Drawer/DrawerSidebarViewController.swift
@@ -24,7 +24,7 @@ final class DrawerSidebarViewController: UIViewController, NeedsDependency {
 
     let headerView = DrawerSidebarHeaderView()    
     
-    let tableView: UITableView = {
+    let sidebarTableView: UITableView = {
         let tableView = UITableView()
         tableView.register(DrawerSidebarEntryTableViewCell.self, forCellReuseIdentifier: String(describing: DrawerSidebarEntryTableViewCell.self))
         tableView.tableFooterView = UIView()
@@ -32,9 +32,9 @@ final class DrawerSidebarViewController: UIViewController, NeedsDependency {
         return tableView
     }()
     
-    let pinnedTableViewSeparatorLine = SeparatorLineView()
+    let settingTableViewSeparatorLine = SeparatorLineView()
     
-    let pinnedTableView: UITableView = {
+    let settingTableView: UITableView = {
         let tableView = UITableView()
         tableView.register(DrawerSidebarEntryTableViewCell.self, forCellReuseIdentifier: String(describing: DrawerSidebarEntryTableViewCell.self))
         tableView.tableFooterView = UIView()
@@ -63,37 +63,31 @@ extension DrawerSidebarViewController {
             headerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             headerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
-//
-//        pinnedTableView.translatesAutoresizingMaskIntoConstraints = false
-//        view.addSubview(pinnedTableView)
-//        NSLayoutConstraint.activate([
-//            pinnedTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-//            view.trailingAnchor.constraint(equalTo: pinnedTableView.trailingAnchor),
-//            view.layoutMarginsGuide.bottomAnchor.constraint(equalTo: pinnedTableView.bottomAnchor),
-//            pinnedTableView.heightAnchor.constraint(equalToConstant: 56).priority(.defaultHigh),
-//        ])
-//
-//        pinnedTableViewSeparatorLine.translatesAutoresizingMaskIntoConstraints = false
-//        view.addSubview(pinnedTableViewSeparatorLine)
-//        NSLayoutConstraint.activate([
-//            pinnedTableViewSeparatorLine.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
-//            view.layoutMarginsGuide.trailingAnchor.constraint(equalTo: pinnedTableViewSeparatorLine.trailingAnchor),
-//            pinnedTableView.topAnchor.constraint(equalTo: pinnedTableViewSeparatorLine.bottomAnchor),
-//            pinnedTableViewSeparatorLine.heightAnchor.constraint(equalToConstant: UIView.separatorLineHeight(of: view)).priority(.defaultHigh),
-//        ])
-//
-//        tableView.delegate = self
-//        pinnedTableView.delegate = self
-//        tableViewDiffableDataSource = setupTableViewDiffableDataSource(tableView: tableView)
-//        pinnedTableViewDiffableDataSource = setupTableViewDiffableDataSource(tableView: pinnedTableView)
-//
-//        var pinnedTableViewDiffableDataSourceSnapshot = NSDiffableDataSourceSnapshot<SidebarSection, SidebarItem>()
-//        pinnedTableViewDiffableDataSourceSnapshot.appendSections([.main])
-//        pinnedTableViewDiffableDataSourceSnapshot.appendItems([.settings], toSection: .main)
-//        pinnedTableViewDiffableDataSource.apply(pinnedTableViewDiffableDataSourceSnapshot)
-        
-        
-//
+
+        settingTableView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(settingTableView)
+        NSLayoutConstraint.activate([
+            settingTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: settingTableView.trailingAnchor),
+            view.layoutMarginsGuide.bottomAnchor.constraint(equalTo: settingTableView.bottomAnchor),
+            settingTableView.heightAnchor.constraint(equalToConstant: 56).priority(.defaultHigh),
+        ])
+
+        settingTableViewSeparatorLine.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(settingTableViewSeparatorLine)
+        NSLayoutConstraint.activate([
+            settingTableViewSeparatorLine.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: settingTableViewSeparatorLine.trailingAnchor),
+            settingTableView.topAnchor.constraint(equalTo: settingTableViewSeparatorLine.bottomAnchor),
+            settingTableViewSeparatorLine.heightAnchor.constraint(equalToConstant: UIView.separatorLineHeight(of: view)).priority(.defaultHigh),
+        ])
+
+        sidebarTableView.delegate = self
+        settingTableView.delegate = self
+        viewModel.setupDiffableDataSource(
+            sidebarTableView: sidebarTableView,
+            settingTableView: settingTableView
+        )
         
         context.authenticationService.activeAuthenticationContext
             .sink { [weak self] authenticationContext in
@@ -102,44 +96,12 @@ extension DrawerSidebarViewController {
                 self.headerView.configure(user: user)
             }
             .store(in: &disposeBag)
-//        context.authenticationService.activeAuthenticationIndex
-//            .receive(on: DispatchQueue.main)
-//            .sink { [weak self] activeAuthenticationIndex in
-//                guard let self = self else { return }
-//                let twitterUser = activeAuthenticationIndex?.twitterAuthentication?.twitterUser
-//                // bind avatar
-//                self.headerView.configure(withConfigurationInput: AvatarConfigurableViewConfiguration.Input(avatarImageURL: twitterUser?.avatarImageURL()))
-//                self.headerView.lockImageView.isHidden = twitterUser.flatMap { !$0.protected } ?? true
-//
-//                // bind name
-//                self.headerView.nameMetaLabel.setTitle(twitterUser?.name ?? "-", for: .normal)
-//                self.headerView.usernameLabel.setTitle(twitterUser.flatMap { "@" + $0.username } ?? "-", for: .normal)
-//
-//                // bind status
-////                self.headerView.profileBannerStatusView.followingStatusItemView.countLabel.text = twitterUser?.metrics?.followingCount.flatMap { "\($0.intValue)" } ?? "-"
-////                self.headerView.profileBannerStatusView.followersStatusItemView.countLabel.text = twitterUser?.metrics?.followersCount.flatMap { "\($0.intValue)" } ?? "-"
-////                self.headerView.profileBannerStatusView.listedStatusItemView.countLabel.text = twitterUser?.metrics?.listedCount.flatMap { "\($0.intValue)" } ?? "-"
-//            }
-//            .store(in: &disposeBag)
         
         headerView.delegate = self
     }
     
 }
 
-extension DrawerSidebarViewController {
-    
-//    func setupTableViewDiffableDataSource(tableView: UITableView) -> UITableViewDiffableDataSource<SidebarSection, SidebarItem> {
-//        return UITableViewDiffableDataSource<SidebarSection, SidebarItem>(tableView: tableView) { tableView, indexPath, item -> UITableViewCell? in
-//            let cell = tableView.dequeueReusableCell(withIdentifier: String(describing: DrawerSidebarEntryTableViewCell.self), for: indexPath) as! DrawerSidebarEntryTableViewCell
-//            cell.entryView.iconImageView.image = item.image
-//            cell.entryView.iconImageView.tintColor = UIColor.label.withAlphaComponent(0.8)
-//            cell.entryView.titleLabel.text = item.title
-//            cell.entryView.titleLabel.textColor = UIColor.label.withAlphaComponent(0.8)
-//            return cell
-//        }
-//    }
-}
 
 // MARK: - DrawerSidebarHeaderViewDelegate
 extension DrawerSidebarViewController: DrawerSidebarHeaderViewDelegate {
@@ -178,19 +140,21 @@ extension DrawerSidebarViewController: DrawerSidebarHeaderViewDelegate {
 
 }
 
-//// MARK: - UITableViewDelegate
-//extension DrawerSidebarViewController: UITableViewDelegate {
-//
-//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-//        if tableView === self.tableView {
-//
-//        }
-//
-//        if tableView === pinnedTableView {
-//            dismiss(animated: true) {
-//                self.coordinator.present(scene: .setting, from: nil, transition: .modal(animated: true, completion: nil))
-//            }
-//        }
-//    }
-//
-//}
+// MARK: - UITableViewDelegate
+extension DrawerSidebarViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        switch tableView {
+        case sidebarTableView:
+            break
+        case settingTableView:
+            dismiss(animated: true) {
+                self.coordinator.present(scene: .setting, from: nil, transition: .modal(animated: true, completion: nil))
+            }
+        default:
+            assertionFailure()
+            break
+        }
+    }
+
+}

--- a/TwidereX/Scene/Sidebar/Drawer/DrawerSidebarViewController.swift
+++ b/TwidereX/Scene/Sidebar/Drawer/DrawerSidebarViewController.swift
@@ -10,16 +10,17 @@ import os.log
 import UIKit
 import Combine
 import AlamofireImage
+import TwidereUI
 
 final class DrawerSidebarViewController: UIViewController, NeedsDependency {
+    
+    let logger = Logger(subsystem: "DrawerSidebarViewController", category: "ViewController")
     
     weak var context: AppContext! { willSet { precondition(!isViewLoaded) } }
     weak var coordinator: SceneCoordinator! { willSet { precondition(!isViewLoaded) } }
 
     var disposeBag = Set<AnyCancellable>()
-    
-    var tableViewDiffableDataSource: UITableViewDiffableDataSource<SidebarSection, SidebarItem>!
-    var pinnedTableViewDiffableDataSource: UITableViewDiffableDataSource<SidebarSection, SidebarItem>!
+    var viewModel: DrawerSidebarViewModel!
 
     let headerView = DrawerSidebarHeaderView()    
     
@@ -31,7 +32,8 @@ final class DrawerSidebarViewController: UIViewController, NeedsDependency {
         return tableView
     }()
     
-    let pinnedTableViewSeparatorLine = UIView.separatorLine
+    let pinnedTableViewSeparatorLine = SeparatorLineView()
+    
     let pinnedTableView: UITableView = {
         let tableView = UITableView()
         tableView.register(DrawerSidebarEntryTableViewCell.self, forCellReuseIdentifier: String(describing: DrawerSidebarEntryTableViewCell.self))
@@ -53,6 +55,7 @@ extension DrawerSidebarViewController {
         super.viewDidLoad()
         
         view.backgroundColor = .systemBackground
+        
         headerView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(headerView)
         NSLayoutConstraint.activate([
@@ -60,137 +63,134 @@ extension DrawerSidebarViewController {
             headerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             headerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
+//
+//        pinnedTableView.translatesAutoresizingMaskIntoConstraints = false
+//        view.addSubview(pinnedTableView)
+//        NSLayoutConstraint.activate([
+//            pinnedTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+//            view.trailingAnchor.constraint(equalTo: pinnedTableView.trailingAnchor),
+//            view.layoutMarginsGuide.bottomAnchor.constraint(equalTo: pinnedTableView.bottomAnchor),
+//            pinnedTableView.heightAnchor.constraint(equalToConstant: 56).priority(.defaultHigh),
+//        ])
+//
+//        pinnedTableViewSeparatorLine.translatesAutoresizingMaskIntoConstraints = false
+//        view.addSubview(pinnedTableViewSeparatorLine)
+//        NSLayoutConstraint.activate([
+//            pinnedTableViewSeparatorLine.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
+//            view.layoutMarginsGuide.trailingAnchor.constraint(equalTo: pinnedTableViewSeparatorLine.trailingAnchor),
+//            pinnedTableView.topAnchor.constraint(equalTo: pinnedTableViewSeparatorLine.bottomAnchor),
+//            pinnedTableViewSeparatorLine.heightAnchor.constraint(equalToConstant: UIView.separatorLineHeight(of: view)).priority(.defaultHigh),
+//        ])
+//
+//        tableView.delegate = self
+//        pinnedTableView.delegate = self
+//        tableViewDiffableDataSource = setupTableViewDiffableDataSource(tableView: tableView)
+//        pinnedTableViewDiffableDataSource = setupTableViewDiffableDataSource(tableView: pinnedTableView)
+//
+//        var pinnedTableViewDiffableDataSourceSnapshot = NSDiffableDataSourceSnapshot<SidebarSection, SidebarItem>()
+//        pinnedTableViewDiffableDataSourceSnapshot.appendSections([.main])
+//        pinnedTableViewDiffableDataSourceSnapshot.appendItems([.settings], toSection: .main)
+//        pinnedTableViewDiffableDataSource.apply(pinnedTableViewDiffableDataSourceSnapshot)
         
-        pinnedTableView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(pinnedTableView)
-        NSLayoutConstraint.activate([
-            pinnedTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            view.trailingAnchor.constraint(equalTo: pinnedTableView.trailingAnchor),
-            view.layoutMarginsGuide.bottomAnchor.constraint(equalTo: pinnedTableView.bottomAnchor),
-            pinnedTableView.heightAnchor.constraint(equalToConstant: 56).priority(.defaultHigh),
-        ])
         
-        pinnedTableViewSeparatorLine.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(pinnedTableViewSeparatorLine)
-        NSLayoutConstraint.activate([
-            pinnedTableViewSeparatorLine.leadingAnchor.constraint(equalTo: view.layoutMarginsGuide.leadingAnchor),
-            view.layoutMarginsGuide.trailingAnchor.constraint(equalTo: pinnedTableViewSeparatorLine.trailingAnchor),
-            pinnedTableView.topAnchor.constraint(equalTo: pinnedTableViewSeparatorLine.bottomAnchor),
-            pinnedTableViewSeparatorLine.heightAnchor.constraint(equalToConstant: UIView.separatorLineHeight(of: view)).priority(.defaultHigh),
-        ])
+//
         
-        headerView.delegate = self
-        
-        tableView.delegate = self
-        pinnedTableView.delegate = self
-        tableViewDiffableDataSource = setupTableViewDiffableDataSource(tableView: tableView)
-        pinnedTableViewDiffableDataSource = setupTableViewDiffableDataSource(tableView: pinnedTableView)
-        
-        var pinnedTableViewDiffableDataSourceSnapshot = NSDiffableDataSourceSnapshot<SidebarSection, SidebarItem>()
-        pinnedTableViewDiffableDataSourceSnapshot.appendSections([.main])
-        pinnedTableViewDiffableDataSourceSnapshot.appendItems([.settings], toSection: .main)
-        pinnedTableViewDiffableDataSource.apply(pinnedTableViewDiffableDataSourceSnapshot)
-        
-        context.authenticationService.activeAuthenticationIndex
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] activeAuthenticationIndex in
+        context.authenticationService.activeAuthenticationContext
+            .sink { [weak self] authenticationContext in
                 guard let self = self else { return }
-                let twitterUser = activeAuthenticationIndex?.twitterAuthentication?.twitterUser
-                // bind avatar
-                self.headerView.configure(withConfigurationInput: AvatarConfigurableViewConfiguration.Input(avatarImageURL: twitterUser?.avatarImageURL()))
-                self.headerView.lockImageView.isHidden = twitterUser.flatMap { !$0.protected } ?? true
-                
-                // bind name
-                self.headerView.nameButton.setTitle(twitterUser?.name ?? "-", for: .normal)
-                self.headerView.usernameButton.setTitle(twitterUser.flatMap { "@" + $0.username } ?? "-", for: .normal) 
-                
-                // bind status
-//                self.headerView.profileBannerStatusView.followingStatusItemView.countLabel.text = twitterUser?.metrics?.followingCount.flatMap { "\($0.intValue)" } ?? "-"
-//                self.headerView.profileBannerStatusView.followersStatusItemView.countLabel.text = twitterUser?.metrics?.followersCount.flatMap { "\($0.intValue)" } ?? "-"
-//                self.headerView.profileBannerStatusView.listedStatusItemView.countLabel.text = twitterUser?.metrics?.listedCount.flatMap { "\($0.intValue)" } ?? "-"
+                let user = authenticationContext?.user(in: self.context.managedObjectContext)
+                self.headerView.configure(user: user)
             }
             .store(in: &disposeBag)
+//        context.authenticationService.activeAuthenticationIndex
+//            .receive(on: DispatchQueue.main)
+//            .sink { [weak self] activeAuthenticationIndex in
+//                guard let self = self else { return }
+//                let twitterUser = activeAuthenticationIndex?.twitterAuthentication?.twitterUser
+//                // bind avatar
+//                self.headerView.configure(withConfigurationInput: AvatarConfigurableViewConfiguration.Input(avatarImageURL: twitterUser?.avatarImageURL()))
+//                self.headerView.lockImageView.isHidden = twitterUser.flatMap { !$0.protected } ?? true
+//
+//                // bind name
+//                self.headerView.nameMetaLabel.setTitle(twitterUser?.name ?? "-", for: .normal)
+//                self.headerView.usernameLabel.setTitle(twitterUser.flatMap { "@" + $0.username } ?? "-", for: .normal)
+//
+//                // bind status
+////                self.headerView.profileBannerStatusView.followingStatusItemView.countLabel.text = twitterUser?.metrics?.followingCount.flatMap { "\($0.intValue)" } ?? "-"
+////                self.headerView.profileBannerStatusView.followersStatusItemView.countLabel.text = twitterUser?.metrics?.followersCount.flatMap { "\($0.intValue)" } ?? "-"
+////                self.headerView.profileBannerStatusView.listedStatusItemView.countLabel.text = twitterUser?.metrics?.listedCount.flatMap { "\($0.intValue)" } ?? "-"
+//            }
+//            .store(in: &disposeBag)
+        
+        headerView.delegate = self
     }
     
 }
 
 extension DrawerSidebarViewController {
     
-    func setupTableViewDiffableDataSource(tableView: UITableView) -> UITableViewDiffableDataSource<SidebarSection, SidebarItem> {
-        return UITableViewDiffableDataSource<SidebarSection, SidebarItem>(tableView: tableView) { tableView, indexPath, item -> UITableViewCell? in
-            let cell = tableView.dequeueReusableCell(withIdentifier: String(describing: DrawerSidebarEntryTableViewCell.self), for: indexPath) as! DrawerSidebarEntryTableViewCell
-            cell.entryView.iconImageView.image = item.image
-            cell.entryView.iconImageView.tintColor = UIColor.label.withAlphaComponent(0.8)
-            cell.entryView.titleLabel.text = item.title
-            cell.entryView.titleLabel.textColor = UIColor.label.withAlphaComponent(0.8)
-            return cell
-        }
-    }
+//    func setupTableViewDiffableDataSource(tableView: UITableView) -> UITableViewDiffableDataSource<SidebarSection, SidebarItem> {
+//        return UITableViewDiffableDataSource<SidebarSection, SidebarItem>(tableView: tableView) { tableView, indexPath, item -> UITableViewCell? in
+//            let cell = tableView.dequeueReusableCell(withIdentifier: String(describing: DrawerSidebarEntryTableViewCell.self), for: indexPath) as! DrawerSidebarEntryTableViewCell
+//            cell.entryView.iconImageView.image = item.image
+//            cell.entryView.iconImageView.tintColor = UIColor.label.withAlphaComponent(0.8)
+//            cell.entryView.titleLabel.text = item.title
+//            cell.entryView.titleLabel.textColor = UIColor.label.withAlphaComponent(0.8)
+//            return cell
+//        }
+//    }
 }
 
 // MARK: - DrawerSidebarHeaderViewDelegate
 extension DrawerSidebarViewController: DrawerSidebarHeaderViewDelegate {
-    
-    private func presentMeProfile() {
+
+
+    func drawerSidebarHeaderView(_ headerView: DrawerSidebarHeaderView, avatarButtonDidPressed button: UIButton) {
         let profileViewModel = MeProfileViewModel(context: self.context)
+        
+        // present from `presentingViewController` here to reduce transition delay
         coordinator.present(scene: .profile(viewModel: profileViewModel), from: presentingViewController, transition: .show)
         dismiss(animated: true)
     }
-    
-    func drawerSidebarHeaderView(_ headerView: DrawerSidebarHeaderView, avatarButtonDidPressed button: UIButton) {
-        presentMeProfile()
-    }
-    
-    func drawerSidebarHeaderView(_ headerView: DrawerSidebarHeaderView, nameButtonDidPressed button: UIButton) {
-        presentMeProfile()
-    }
-    
-    func drawerSidebarHeaderView(_ headerView: DrawerSidebarHeaderView, usernameButtonDidPressed button: UIButton) {
-        presentMeProfile()
-    }
-    
+
     func drawerSidebarHeaderView(_ headerView: DrawerSidebarHeaderView, menuButtonDidPressed button: UIButton) {
         dismiss(animated: true) {
             let accountListViewModel = AccountListViewModel(context: self.context)
             self.coordinator.present(scene: .accountList(viewModel: accountListViewModel), from: nil, transition: .modal(animated: true, completion: nil))
         }
     }
-    
+
     func drawerSidebarHeaderView(_ headerView: DrawerSidebarHeaderView, closeButtonDidPressed button: UIButton) {
         dismiss(animated: true, completion: nil)
     }
     
-    func drawerSidebarHeaderView(_ headerView: DrawerSidebarHeaderView, profileBannerStatusView: ProfileBannerStatusView, followingStatusItemViewDidPressed statusItemView: ProfileBannerStatusItemView) {
-        guard let followingListViewModel = FriendshipListViewModel(context: context, friendshipLookupKind: .following) else { return }
-        coordinator.present(scene: .friendshipList(viewModel: followingListViewModel), from: presentingViewController, transition: .show)
-        dismiss(animated: true)
+    func drawerSidebarHeaderView(_ headerView: DrawerSidebarHeaderView, profileDashboardView: ProfileDashboardView, followingMeterViewDidPressed meterView: ProfileDashboardMeterView) {
+        // TODO:
     }
     
-    func drawerSidebarHeaderView(_ headerView: DrawerSidebarHeaderView, profileBannerStatusView: ProfileBannerStatusView, followerStatusItemViewDidPressed statusItemView: ProfileBannerStatusItemView) {
-        guard let followingListViewModel = FriendshipListViewModel(context: context, friendshipLookupKind: .followers) else { return }
-        coordinator.present(scene: .friendshipList(viewModel: followingListViewModel), from: presentingViewController, transition: .show)
-        dismiss(animated: true)
+    func drawerSidebarHeaderView(_ headerView: DrawerSidebarHeaderView, profileDashboardView: ProfileDashboardView, followersMeterViewDidPressed meterView: ProfileDashboardMeterView) {
+        // TODO:
     }
     
-    func drawerSidebarHeaderView(_ headerView: DrawerSidebarHeaderView, profileBannerStatusView: ProfileBannerStatusView, listedStatusItemViewDidPressed statusItemView: ProfileBannerStatusItemView) {
-        
+    func drawerSidebarHeaderView(_ headerView: DrawerSidebarHeaderView, profileDashboardView: ProfileDashboardView, listedMeterViewDidPressed meterView: ProfileDashboardMeterView) {
+        // TODO:
     }
-        
+
 }
 
-// MARK: - UITableViewDelegate
-extension DrawerSidebarViewController: UITableViewDelegate {
-
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if tableView === self.tableView {
-            
-        }
-        
-        if tableView === pinnedTableView {
-            dismiss(animated: true) {
-                self.coordinator.present(scene: .setting, from: nil, transition: .modal(animated: true, completion: nil))
-            }
-        }
-    }
-    
-}
+//// MARK: - UITableViewDelegate
+//extension DrawerSidebarViewController: UITableViewDelegate {
+//
+//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+//        if tableView === self.tableView {
+//
+//        }
+//
+//        if tableView === pinnedTableView {
+//            dismiss(animated: true) {
+//                self.coordinator.present(scene: .setting, from: nil, transition: .modal(animated: true, completion: nil))
+//            }
+//        }
+//    }
+//
+//}

--- a/TwidereX/Scene/Sidebar/Drawer/DrawerSidebarViewModel+Diffable.swift
+++ b/TwidereX/Scene/Sidebar/Drawer/DrawerSidebarViewModel+Diffable.swift
@@ -1,0 +1,37 @@
+//
+//  DrawerSidebarViewModel+Diffable.swift
+//  TwidereX
+//
+//  Created by MainasuK on 2021-12-2.
+//  Copyright © 2021 Twidere. All rights reserved.
+//
+
+import UIKit
+
+extension DrawerSidebarViewModel {
+    func setupDiffableDataSource(
+        sidebarTableView: UITableView,
+        settingTableView: UITableView
+    ) {
+        sidebarDiffableDataSource = setupDiffableDataSource(tableView: sidebarTableView)
+        settingDiffableDataSource = setupDiffableDataSource(tableView: settingTableView)
+        
+        
+        var settingSnapshot = NSDiffableDataSourceSnapshot<SidebarSection, SidebarItem>()
+        settingSnapshot.appendSections([.main])
+        settingSnapshot.appendItems([.settings], toSection: .main)
+        settingDiffableDataSource?.apply(settingSnapshot)
+    }
+    
+    func setupDiffableDataSource(tableView: UITableView) -> UITableViewDiffableDataSource<SidebarSection, SidebarItem> {
+        UITableViewDiffableDataSource(tableView: tableView) { tableView, indexPath, item in
+            let cell = tableView.dequeueReusableCell(withIdentifier: String(describing: DrawerSidebarEntryTableViewCell.self), for: indexPath) as! DrawerSidebarEntryTableViewCell
+            cell.entryView.iconImageView.image = item.image
+            cell.entryView.iconImageView.tintColor = UIColor.label.withAlphaComponent(0.8)
+            cell.entryView.titleLabel.text = item.title
+            cell.entryView.titleLabel.textColor = UIColor.label.withAlphaComponent(0.8)
+            return cell
+        }
+    }
+    
+}

--- a/TwidereX/Scene/Sidebar/Drawer/DrawerSidebarViewModel.swift
+++ b/TwidereX/Scene/Sidebar/Drawer/DrawerSidebarViewModel.swift
@@ -7,10 +7,26 @@
 //
 
 import UIKit
+import Combine
+import Meta
+import TwidereCore
 
 final class DrawerSidebarViewModel {
     
-    // var diffableDataSource = UITableView
+    var disposeBag = Set<AnyCancellable>()
+    
+    // input
+    let context: AppContext
+    
+    // output
+    var sidebarDiffableDataSource: UITableViewDiffableDataSource<SidebarSection, SidebarItem>?
+    var settingDiffableDataSource: UITableViewDiffableDataSource<SidebarSection, SidebarItem>?
+    
+    init(context: AppContext) {
+        self.context = context
+        // end init
+    }
+    
 }
 
 extension DrawerSidebarViewModel {

--- a/TwidereX/Scene/Sidebar/Drawer/DrawerSidebarViewModel.swift
+++ b/TwidereX/Scene/Sidebar/Drawer/DrawerSidebarViewModel.swift
@@ -28,10 +28,3 @@ final class DrawerSidebarViewModel {
     }
     
 }
-
-extension DrawerSidebarViewModel {
-    
-    func setupDiffableDataSource(for tableView: UITableView) {
-        
-    }
-}

--- a/TwidereX/Scene/Sidebar/Drawer/View/DrawerSidebarHeaderView+ViewModel.swift
+++ b/TwidereX/Scene/Sidebar/Drawer/View/DrawerSidebarHeaderView+ViewModel.swift
@@ -1,0 +1,201 @@
+//
+//  DrawerSidebarHeaderView+ViewModel.swift
+//  TwidereX
+//
+//  Created by MainasuK on 2021-12-2.
+//  Copyright © 2021 Twidere. All rights reserved.
+//
+
+import UIKit
+import Combine
+import MetaTextKit
+import TwidereCommon
+import CoreDataStack
+import TwidereCore
+
+extension DrawerSidebarHeaderView {
+    class ViewModel: ObservableObject {
+        var configureDisposeBag = Set<AnyCancellable>()
+        var bindDisposeBag = Set<AnyCancellable>()
+        
+        @Published var avatarURL: URL?
+        @Published var name: MetaContent?
+        @Published var username: String?
+        
+        @Published var isProtected: Bool = false
+        
+        @Published var followingCount: Int?
+        @Published var followersCount: Int?
+        @Published var listedCount: Int?
+        
+        @Published var needsListCountDashboardMeterDisplay = true
+    }
+}
+
+extension DrawerSidebarHeaderView.ViewModel {
+    func bind(view: DrawerSidebarHeaderView) {
+        // avatar
+        $avatarURL
+            .sink { avatarURL in
+                let configuration = AvatarImageView.Configuration(url: avatarURL)
+                view.avatarView.avatarButton.avatarImageView.configure(configuration: configuration)
+            }
+            .store(in: &bindDisposeBag)
+        // name
+        $name
+            .receive(on: DispatchQueue.main)
+            .sink { name in
+                let metaContent = name ?? PlaintextMetaContent(string: "-")
+                view.nameMetaLabel.configure(content: metaContent)
+            }
+            .store(in: &bindDisposeBag)
+        // username
+        $username
+            .sink { username in
+                let username = username.flatMap { "@" + $0 } ?? "-"
+                view.usernameLabel.text = username
+            }
+            .store(in: &bindDisposeBag)
+        // isProtected
+        $isProtected
+            .map { !$0 }
+            .assign(to: \.isHidden, on: view.lockImageView)
+            .store(in: &bindDisposeBag)
+        // dashboard
+        $followingCount
+            .sink { count in
+                if let count = count {
+                    view.profileDashboardView.followingMeterView.countLabel.text = "\(count)"
+                } else {
+                    view.profileDashboardView.followingMeterView.countLabel.text = "-"
+                }
+            }
+            .store(in: &bindDisposeBag)
+        $followersCount
+            .sink { count in
+                if let count = count {
+                    view.profileDashboardView.followerMeterView.countLabel.text = "\(count)"
+                } else {
+                    view.profileDashboardView.followerMeterView.countLabel.text = "-"
+                }
+            }
+            .store(in: &bindDisposeBag)
+        $listedCount
+            .sink { count in
+                if let count = count {
+                    view.profileDashboardView.listedMeterView.countLabel.text = "\(count)"
+                } else {
+                    view.profileDashboardView.listedMeterView.countLabel.text = "-"
+                }
+            }
+            .store(in: &bindDisposeBag)
+        $needsListCountDashboardMeterDisplay
+            .sink { needsListCountDashboardMeterDisplay in
+                view.profileDashboardView.listedMeterView.isHidden = !needsListCountDashboardMeterDisplay
+                view.profileDashboardView.separatorLine2.isHidden = !needsListCountDashboardMeterDisplay
+            }
+            .store(in: &bindDisposeBag)
+    }
+}
+
+extension DrawerSidebarHeaderView {
+    func configure(user: UserObject?) {
+        // reset
+        viewModel.configureDisposeBag.removeAll()
+        
+        guard let user = user else {
+            reset()
+            return
+        }
+        
+        switch user {
+        case .twitter(let object):
+            configure(twitterUser: object)
+        case .mastodon(let object):
+            configure(mastodonUser: object)
+        }
+    }
+
+    private func reset() {
+        viewModel.avatarURL = nil
+        viewModel.name = nil
+        viewModel.username = nil
+        viewModel.isProtected = false
+        viewModel.followingCount = nil
+        viewModel.followersCount = nil
+        viewModel.listedCount = nil
+        viewModel.needsListCountDashboardMeterDisplay = true
+    }
+}
+
+extension DrawerSidebarHeaderView {
+    func configure(twitterUser user: TwitterUser) {
+        // avatar
+        user.publisher(for: \.profileImageURL)
+            .map { _ in user.avatarImageURL() }
+            .assign(to: \.avatarURL, on: viewModel)
+            .store(in: &viewModel.configureDisposeBag)
+        // name
+        user.publisher(for: \.name)
+            .map { name in PlaintextMetaContent(string: name) }
+            .assign(to: \.name, on: viewModel)
+            .store(in: &viewModel.configureDisposeBag)
+        // username
+        user.publisher(for: \.username)
+            .map { $0 as String? }
+            .assign(to: \.username, on: viewModel)
+            .store(in: &viewModel.configureDisposeBag)
+        // isProtected
+        user.publisher(for: \.protected)
+            .assign(to: \.isProtected, on: viewModel)
+            .store(in: &viewModel.configureDisposeBag)
+        // dashboard
+        user.publisher(for: \.followingCount)
+            .map { Int($0) }
+            .assign(to: \.followingCount, on: viewModel)
+            .store(in: &viewModel.configureDisposeBag)
+        user.publisher(for: \.followersCount)
+            .map { Int($0) }
+            .assign(to: \.followersCount, on: viewModel)
+            .store(in: &viewModel.configureDisposeBag)
+        user.publisher(for: \.listedCount)
+            .map { Int($0) }
+            .assign(to: \.listedCount, on: viewModel)
+            .store(in: &viewModel.configureDisposeBag)
+        viewModel.needsListCountDashboardMeterDisplay = true
+    }
+}
+
+extension DrawerSidebarHeaderView {
+    func configure(mastodonUser user: MastodonUser) {
+        // avatar
+        user.publisher(for: \.avatar)
+            .map { avatar in avatar.flatMap { URL(string: $0) } }
+            .assign(to: \.avatarURL, on: viewModel)
+            .store(in: &viewModel.configureDisposeBag)
+        // name
+        user.publisher(for: \.displayName)
+            .map { _ in user.nameMetaContent }
+            .assign(to: \.name, on: viewModel)
+            .store(in: &viewModel.configureDisposeBag)
+        // username
+        user.publisher(for: \.username)
+            .map { $0 as String? }
+            .assign(to: \.username, on: viewModel)
+            .store(in: &viewModel.configureDisposeBag)
+        // isProtected
+        user.publisher(for: \.locked)
+            .assign(to: \.isProtected, on: viewModel)
+            .store(in: &viewModel.configureDisposeBag)
+        // dashboard
+        user.publisher(for: \.followingCount)
+            .map { Int($0) }
+            .assign(to: \.followingCount, on: viewModel)
+            .store(in: &viewModel.configureDisposeBag)
+        user.publisher(for: \.followersCount)
+            .map { Int($0) }
+            .assign(to: \.followersCount, on: viewModel)
+            .store(in: &viewModel.configureDisposeBag)
+        viewModel.needsListCountDashboardMeterDisplay = false
+    }
+}

--- a/TwidereX/Scene/Transition/DrawerSidebar/DrawerSidebarPresentationController.swift
+++ b/TwidereX/Scene/Transition/DrawerSidebar/DrawerSidebarPresentationController.swift
@@ -13,20 +13,6 @@ final class DrawerSidebarPresentationController: UIPresentationController {
 
     override var shouldRemovePresentersView: Bool { return true }
     
-    override var overrideTraitCollection: UITraitCollection? {
-        get {
-            if UserDefaults.shared.useTheSystemFontSize {
-                return nil
-            } else {
-                let customContentSizeCatagory = UserDefaults.shared.customContentSizeCatagory
-                return UITraitCollection(preferredContentSizeCategory: customContentSizeCatagory)
-            }
-        }
-        set {
-            
-        }
-    }
-
     deinit {
         os_log(.info, log: .debug, "%{public}s[%{public}ld], %{public}s:", ((#file as NSString).lastPathComponent), #line, #function)
     }

--- a/TwidereX/Scene/Transition/DrawerSidebar/DrawerSidebarTransitionController.swift
+++ b/TwidereX/Scene/Transition/DrawerSidebar/DrawerSidebarTransitionController.swift
@@ -9,15 +9,15 @@
 import os.log
 import UIKit
 
-protocol DrawerSidebarTransitionableViewController: UIViewController & NeedsDependency {
+protocol DrawerSidebarTransitionHostViewController: UIViewController & NeedsDependency {
     var drawerSidebarTransitionController: DrawerSidebarTransitionController! { get }
     var avatarBarButtonItem: AvatarBarButtonItem { get }
 }
 
 final class DrawerSidebarTransitionController: NSObject {
     
-    weak var drawerSidebarTransitionableViewController: DrawerSidebarTransitionableViewController?
-    weak var drawerSidebarViewController: DrawerSidebarViewController?
+    weak var hostViewController: DrawerSidebarTransitionHostViewController?
+    weak var sidebarViewController: DrawerSidebarViewController?
     
     private var screenEdgePanGestureRecognizer: UIScreenEdgePanGestureRecognizer = {
         let gestureRecognizer = UIScreenEdgePanGestureRecognizer()
@@ -37,15 +37,16 @@ final class DrawerSidebarTransitionController: NSObject {
     
     var wantsInteractive = false
     
-    init(drawerSidebarTransitionableViewController: DrawerSidebarTransitionableViewController) {
-        self.drawerSidebarTransitionableViewController = drawerSidebarTransitionableViewController
+    init(hostViewController: DrawerSidebarTransitionHostViewController) {
+        self.hostViewController = hostViewController
         super.init()
                 
         // edge pan present gesture
         screenEdgePanGestureRecognizer.delegate = self
         screenEdgePanGestureRecognizer.addTarget(self, action: #selector(DrawerSidebarTransitionController.edgePan(_:)))
-        drawerSidebarTransitionableViewController.view.addGestureRecognizer(screenEdgePanGestureRecognizer)
-        if let interactivePopGestureRecognizer = drawerSidebarTransitionableViewController.navigationController?.interactivePopGestureRecognizer {
+        hostViewController.view.addGestureRecognizer(screenEdgePanGestureRecognizer)
+        
+        if let interactivePopGestureRecognizer = hostViewController.navigationController?.interactivePopGestureRecognizer {
             screenEdgePanGestureRecognizer.require(toFail: interactivePopGestureRecognizer)
         }
         
@@ -68,18 +69,14 @@ extension DrawerSidebarTransitionController {
 extension DrawerSidebarTransitionController: UIViewControllerTransitioningDelegate {
     
     func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        if #available(iOS 14.0, *) {
-            guard !UIAccessibility.prefersCrossFadeTransitions else { return nil }
-        } else {
-            // do nothing
-        }
+        guard !UIAccessibility.prefersCrossFadeTransitions else { return nil }
         
         guard let drawerSidebarViewController = presented as? DrawerSidebarViewController else {
             assertionFailure()
             return nil
         }
 
-        self.drawerSidebarViewController = drawerSidebarViewController
+        self.sidebarViewController = drawerSidebarViewController
         drawerSidebarViewController.view.addGestureRecognizer(panGestureRecognizer)
         return DrawerSidebarAnimatedTransitioning(
             operation: .push,
@@ -103,11 +100,7 @@ extension DrawerSidebarTransitionController: UIViewControllerTransitioningDelega
     }
     
     func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        if #available(iOS 14.0, *) {
-            guard !UIAccessibility.prefersCrossFadeTransitions else { return nil }
-        } else {
-            // do nothing
-        }
+        guard !UIAccessibility.prefersCrossFadeTransitions else { return nil }
         
         return DrawerSidebarAnimatedTransitioning(
             operation: .pop,
@@ -138,9 +131,11 @@ extension DrawerSidebarTransitionController: UIViewControllerTransitioningDelega
 
 extension DrawerSidebarTransitionController {
 
+    @MainActor
     @objc private func edgePan(_ sender: UIPanGestureRecognizer) {
         guard let transitionType = transitionType else { return }
         guard sender.state == .began else { return }
+        guard let hostViewController = hostViewController else { return }
 
         // check transition is not on the fly
         guard interactiveTransitioning == nil else {
@@ -150,12 +145,11 @@ extension DrawerSidebarTransitionController {
         switch transitionType {
         case .present:
             wantsInteractive = true
-            // FIXME:
-//            drawerSidebarTransitionableViewController?.coordinator.present(
-//                scene: .drawerSidebar,
-//                from: drawerSidebarTransitionableViewController,
-//                transition: .custom(transitioningDelegate: self)
-//            )
+            hostViewController.coordinator.present(
+                scene: .drawerSidebar(viewModel: DrawerSidebarViewModel(context: hostViewController.context)),
+                from: hostViewController,
+                transition: .custom(transitioningDelegate: self)
+            )
 
         case .dismiss:
             assertionFailure()
@@ -178,7 +172,7 @@ extension DrawerSidebarTransitionController {
             break
         case .dismiss:
             wantsInteractive = true
-            drawerSidebarViewController?.dismiss(animated: true, completion: nil)
+            sidebarViewController?.dismiss(animated: true, completion: nil)
         }
     }
 
@@ -188,7 +182,7 @@ extension DrawerSidebarTransitionController {
 extension DrawerSidebarTransitionController: UIGestureRecognizerDelegate {
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        if drawerSidebarTransitionableViewController?.navigationController?.topViewController is DrawerSidebarTransitionableViewController {
+        if hostViewController?.navigationController?.topViewController is DrawerSidebarTransitionHostViewController {
             if (gestureRecognizer is UIPanGestureRecognizer && otherGestureRecognizer.view is UITableView) ||
                (otherGestureRecognizer is UIPanGestureRecognizer && gestureRecognizer.view is UITableView) {
                 // disable tableView scroll when pan
@@ -214,12 +208,12 @@ extension DrawerSidebarTransitionController: UIGestureRecognizerDelegate {
             return wantsInteractive
         }
         
-        if gestureRecognizer === screenEdgePanGestureRecognizer, drawerSidebarTransitionableViewController != nil {
+        if gestureRecognizer === screenEdgePanGestureRecognizer, hostViewController != nil {
             transitionType = .present
             return true
         }
         
-        if gestureRecognizer === panGestureRecognizer, drawerSidebarViewController != nil {
+        if gestureRecognizer === panGestureRecognizer, sidebarViewController != nil {
             transitionType = .dismiss
             return true
         }


### PR DESCRIPTION
Restore the drawer sidebar UI. 

The user could tap on avatar bar button item or pan from screen edge to present sidebar. UX behavior is same to current App Store version. Also, the iPad sidebar adaption is plan in the next build after current dev build.