### PR TITLE
Fix MediaView reuse issue

### DIFF
--- a/TwidereSDK/Sources/TwidereUI/Container/MediaGridContainerView.swift
+++ b/TwidereSDK/Sources/TwidereUI/Container/MediaGridContainerView.swift
@@ -47,7 +47,6 @@ public final class MediaGridContainerView: UIView {
         return mediaViews
     }()
     
-    
     let sensitiveToggleButtonBlurVisualEffectView: UIVisualEffectView = {
         let visualEffectView = UIVisualEffectView(effect: ContentWarningOverlayView.blurVisualEffect)
         visualEffectView.layer.masksToBounds = true

--- a/TwidereSDK/Sources/TwidereUI/Content/MediaView.swift
+++ b/TwidereSDK/Sources/TwidereUI/Content/MediaView.swift
@@ -112,10 +112,6 @@ extension MediaView {
         }
     }
     
-    private func prepareForReuse() {
-        imageView.isHidden = false
-    }
-    
     private func configure(
         image info: Configuration.ImageInfo,
         containerView: UIView
@@ -241,6 +237,7 @@ extension MediaView {
         imageView.removeConstraints(imageView.constraints)
         imageView.af.cancelImageRequest()
         imageView.image = nil
+        imageView.isHidden = false
         
         // reset player
         playerViewController.view.removeFromSuperview()

--- a/TwidereSDK/Sources/TwidereUI/Content/MediaView.swift
+++ b/TwidereSDK/Sources/TwidereUI/Content/MediaView.swift
@@ -100,6 +100,7 @@ extension MediaView {
         self.configuration = configuration
 
         setupContainerViewHierarchy()
+        prepareForReuse()
         
         switch configuration {
         case .image(let info):
@@ -109,6 +110,10 @@ extension MediaView {
         case .video(let info):
             configure(video: info)
         }
+    }
+    
+    private func prepareForReuse() {
+        imageView.isHidden = false
     }
     
     private func configure(

--- a/TwidereSDK/Sources/TwidereUI/Content/MediaView.swift
+++ b/TwidereSDK/Sources/TwidereUI/Content/MediaView.swift
@@ -100,7 +100,6 @@ extension MediaView {
         self.configuration = configuration
 
         setupContainerViewHierarchy()
-        prepareForReuse()
         
         switch configuration {
         case .image(let info):

--- a/TwidereX.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TwidereX.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "12f2389aca4a07e0dd54c86ec23d0721ed88b8db",
-          "version": "1.4.3"
+          "revision": "039f56c5d7960f277087a0be51f5eb04ed0ec073",
+          "version": "1.5.1"
         }
       },
       {
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/google/gtm-session-fetcher.git",
         "state": {
           "branch": null,
-          "revision": "eca9404a18f53727e4698211aaf2615eb93b962a",
-          "version": "1.7.1"
+          "revision": "4e9bbf2808b8fee444e84a48f5f3c12641987d3e",
+          "version": "1.7.2"
         }
       },
       {

--- a/TwidereX.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TwidereX.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -222,8 +222,8 @@
         "repositoryURL": "https://github.com/SDWebImage/SDWebImage.git",
         "state": {
           "branch": null,
-          "revision": "2e63d0061da449ad0ed130768d05dceb1496de44",
-          "version": "5.12.5"
+          "revision": "a72df4849408da7e5d3c1b586797b7c601c41d1b",
+          "version": "5.12.1"
         }
       },
       {


### PR DESCRIPTION
The MediaView get hidden by accident when reusing due to `prepareForReuse` method missing.