### PR TITLE
Fix compose view drop in media not working issue

### DIFF
--- a/TwidereSDK/Sources/TwidereUI/Scene/ComposeContent/Attachment/AttachmentViewModel.swift
+++ b/TwidereSDK/Sources/TwidereUI/Scene/ComposeContent/Attachment/AttachmentViewModel.swift
@@ -254,17 +254,25 @@ extension AttachmentViewModel {
 // MARK: - TypeIdentifiedItemProvider
 extension AttachmentViewModel: TypeIdentifiedItemProvider {
     public static var typeIdentifier: String {
-        return Bundle(for: AttachmentViewModel.self).bundleIdentifier! + String(describing: type(of: AttachmentViewModel.self))
+        // must in UTI format
+        // https://developer.apple.com/library/archive/qa/qa1796/_index.html
+        return "com.twidere.AttachmentViewModel"
     }
 }
 
 // MARK: - NSItemProviderWriting
 extension AttachmentViewModel: NSItemProviderWriting {
     
+    
+    /// Attachment uniform type idendifiers
+    ///
+    /// The latest one for in-app drag and drop.
+    /// And use generic `image` and `movie` type to
+    /// allows transformable media in different formats
     public static var writableTypeIdentifiersForItemProvider: [String] {
         return [
-            UTType.png.identifier,
-            UTType.mpeg4Movie.identifier,
+            UTType.image.identifier,
+            UTType.movie.identifier,
             AttachmentViewModel.typeIdentifier,
         ]
     }

--- a/TwidereX/Info.plist
+++ b/TwidereX/Info.plist
@@ -82,5 +82,22 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>AttachmentViewModel</string>
+			<key>UTTypeIconFiles</key>
+			<array/>
+			<key>UTTypeIdentifier</key>
+			<string>com.twidere.AttachmentViewModel</string>
+			<key>UTTypeTagSpecification</key>
+			<dict/>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Now the custom attachment get registered UTI to allow reorder. 
And drop in not working issue fixed by accepts more generic media type.