### PR TITLE
Fix Twitter media save quality issue

### DIFF
--- a/TwidereSDK/Sources/CoreDataStack/Entity/Transient/Mastodon/MastodonAttachment.swift
+++ b/TwidereSDK/Sources/CoreDataStack/Entity/Transient/Mastodon/MastodonAttachment.swift
@@ -56,3 +56,9 @@ extension MastodonAttachment {
         case audio
     }
 }
+
+extension MastodonAttachment {
+    public var downloadURL: String? {
+        return assetURL
+    }
+}

--- a/TwidereSDK/Sources/CoreDataStack/Entity/Transient/Twitter/TwitterAttachment.swift
+++ b/TwidereSDK/Sources/CoreDataStack/Entity/Transient/Twitter/TwitterAttachment.swift
@@ -47,3 +47,32 @@ extension TwitterAttachment {
         }
     }
 }
+
+extension TwitterAttachment {
+    
+    public enum Size: String {
+        case thumbnail = "thumb"
+        case small
+        case medium
+        case large
+        case original = "orig"
+    }
+    
+    public var downloadURL: String? {
+        switch kind {
+        case .photo:
+            guard let urlString = self.assetURL, var url = URL(string: urlString) else { return assetURL }
+            let format = url.pathExtension
+            url.deletePathExtension()
+            guard var component = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return assetURL }
+            component.queryItems = [
+                URLQueryItem(name: "format", value: format),
+                URLQueryItem(name: "name", value: Size.original.rawValue)
+            ]
+            guard let downloadURL = component.url else { return assetURL }
+            return downloadURL.absoluteString
+        default:
+            return assetURL
+        }
+    }
+}

--- a/TwidereSDK/Sources/TwidereCore/Model/Attachment/AttachmentObject.swift
+++ b/TwidereSDK/Sources/TwidereCore/Model/Attachment/AttachmentObject.swift
@@ -59,6 +59,15 @@ extension AttachmentObject {
             return mastodonAttachment.previewURL.flatMap { URL(string: $0) }
         }
     }
+    
+    public var downloadURL: URL? {
+        switch self {
+        case .twitter(let twitterAttachment):
+            return twitterAttachment.downloadURL.flatMap { URL(string: $0) }
+        case .mastodon(let mastodonAttachment):
+            return mastodonAttachment.assetURL.flatMap { URL(string: $0) }
+        }
+    }
 }
 
 extension AttachmentObject {

--- a/TwidereSDK/Sources/TwidereUI/Content/MediaView+Configuration.swift
+++ b/TwidereSDK/Sources/TwidereUI/Content/MediaView+Configuration.swift
@@ -37,6 +37,17 @@ extension MediaView {
             }
         }
         
+        public var downloadURL: String? {
+            switch self {
+            case .image(let info):
+                return info.downloadURL ?? info.assetURL
+            case .gif(let info):
+                return info.assetURL
+            case .video(let info):
+                return info.assetURL
+            }
+        }
+        
         public var resourceType: PHAssetResourceType {
             switch self {
             case .image:
@@ -51,13 +62,16 @@ extension MediaView {
         public struct ImageInfo: Hashable {
             public let aspectRadio: CGSize
             public let assetURL: String?
+            public let downloadURL: String?
             
             public init(
                 aspectRadio: CGSize,
-                assetURL: String?
+                assetURL: String?,
+                downloadURL: String?
             ) {
                 self.aspectRadio = aspectRadio
                 self.assetURL = assetURL
+                self.downloadURL = downloadURL
             }
             
             public func hash(into hasher: inout Hasher) {
@@ -113,7 +127,8 @@ extension MediaView {
             case .photo:
                 let info = MediaView.Configuration.ImageInfo(
                     aspectRadio: attachment.size,
-                    assetURL: attachment.assetURL
+                    assetURL: attachment.assetURL,
+                    downloadURL: attachment.downloadURL
                 )
                 return .image(info: info)
             case .video:
@@ -142,7 +157,8 @@ extension MediaView {
             case .image:
                 let info = MediaView.Configuration.ImageInfo(
                     aspectRadio: attachment.size,
-                    assetURL: attachment.assetURL
+                    assetURL: attachment.assetURL,
+                    downloadURL: attachment.downloadURL
                 )
                 return .image(info: info)
             case .video:

--- a/TwidereSDK/Sources/TwidereUI/Content/MediaView.swift
+++ b/TwidereSDK/Sources/TwidereUI/Content/MediaView.swift
@@ -169,7 +169,8 @@ extension MediaView {
         if let contentOverlayView = playerViewController.contentOverlayView {
             let imageInfo = Configuration.ImageInfo(
                 aspectRadio: info.aspectRadio,
-                assetURL: info.previewURL
+                assetURL: info.previewURL,
+                downloadURL: info.previewURL
             )
             configure(image: imageInfo, containerView: contentOverlayView)
             
@@ -206,7 +207,8 @@ extension MediaView {
     private func configure(video info: Configuration.VideoInfo) {
         let imageInfo = Configuration.ImageInfo(
             aspectRadio: info.aspectRadio,
-            assetURL: info.previewURL
+            assetURL: info.previewURL,
+            downloadURL: info.previewURL
         )
         configure(image: imageInfo, containerView: container)
         

--- a/TwidereX/Protocol/Provider/DataSourceProvider+StatusViewTableViewCellDelegate.swift
+++ b/TwidereX/Protocol/Provider/DataSourceProvider+StatusViewTableViewCellDelegate.swift
@@ -370,7 +370,7 @@ extension StatusViewTableViewCellDelegate where Self: DataSourceProvider {
                 do {
                     await impactFeedbackGenerator.impactOccurred()
                     for configuration in mediaViewConfigurations {
-                        guard let url = configuration.assetURL.flatMap({ URL(string: $0) }) else { continue }
+                        guard let url = configuration.downloadURL.flatMap({ URL(string: $0) }) else { continue }
                         try await context.photoLibraryService.save(source: .remote(url: url), resourceType: configuration.resourceType)
                     }
                     await context.photoLibraryService.presentSuccessNotification(title: L10n.Common.Alerts.PhotoSaved.title)

--- a/TwidereX/Protocol/Provider/DataSourceProvider+UITableViewDelegate.swift
+++ b/TwidereX/Protocol/Provider/DataSourceProvider+UITableViewDelegate.swift
@@ -59,7 +59,7 @@ extension UITableViewDelegate where Self: DataSourceProvider & MediaPreviewableV
                 continue
             }
             guard let image = mediaView.thumbnail(),
-                  let assetURLString = mediaView.configuration?.assetURL,
+                  let assetURLString = mediaView.configuration?.downloadURL,
                   let assetURL = URL(string: assetURLString),
                   let resourceType = mediaView.configuration?.resourceType
             else {


### PR DESCRIPTION
Twitter media now uses `original` quality instead of the default `medium` for saving media action. And the media preview still uses the default one for speed.