### PR TITLE
Fix unread indicator count reset when auto fetch trigger

### DIFF
--- a/TwidereX.xcodeproj/project.pbxproj
+++ b/TwidereX.xcodeproj/project.pbxproj
@@ -626,7 +626,6 @@
 		DB5BF12227F5A549002A3EF5 /* PublishPostIntentHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishPostIntentHandler.swift; sourceTree = "<group>"; };
 		DB5BF12427F5A5C1002A3EF5 /* Account+Fetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Account+Fetch.swift"; sourceTree = "<group>"; };
 		DB5BF12C27F5BAD5002A3EF5 /* AuthenticationIndex+Fetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AuthenticationIndex+Fetch.swift"; sourceTree = "<group>"; };
-		DB5CD47F2869A6330095A57D /* MetaTextKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = MetaTextKit; path = ../MetaTextKit; sourceTree = "<group>"; };
 		DB5FD9B226D8D94600CF5439 /* StatusTableViewCell+ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatusTableViewCell+ViewModel.swift"; sourceTree = "<group>"; };
 		DB5FD9B626D8EFF700CF5439 /* UserBriefInfoView+ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserBriefInfoView+ViewModel.swift"; sourceTree = "<group>"; };
 		DB60C1A82762394E00628235 /* AuthenticationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AuthenticationServices.framework; path = System/Library/Frameworks/AuthenticationServices.framework; sourceTree = SDKROOT; };
@@ -1981,7 +1980,6 @@
 		DBDA8E1524FCF8A3006750DC = {
 			isa = PBXGroup;
 			children = (
-				DB5CD47F2869A6330095A57D /* MetaTextKit */,
 				DB33E5B42719637400EC2225 /* CoverFlowStackCollectionViewLayout */,
 				DB51DC372716AEF000A0D8FB /* TabBarPager */,
 				DB43239D251491EB004FAAEC /* TwidereSDK */,

--- a/TwidereX.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TwidereX.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -110,6 +110,15 @@
         }
       },
       {
+        "package": "MetaTextKit",
+        "repositoryURL": "https://github.com/TwidereProject/MetaTextKit.git",
+        "state": {
+          "branch": null,
+          "revision": "f5af64a22d5a4839d68efe74e41216f039194d12",
+          "version": "3.3.2"
+        }
+      },
+      {
         "package": "Pageboy",
         "repositoryURL": "https://github.com/uias/Pageboy",
         "state": {

--- a/TwidereX/Scene/Timeline/Home/HomeTimelineViewController.swift
+++ b/TwidereX/Scene/Timeline/Home/HomeTimelineViewController.swift
@@ -43,7 +43,6 @@ extension HomeTimelineViewController {
             unreadIndicatorView.widthAnchor.constraint(greaterThanOrEqualToConstant: 36).priority(.required - 1),
             unreadIndicatorView.heightAnchor.constraint(greaterThanOrEqualToConstant: 36).priority(.required - 1),
         ])
-        unreadIndicatorView.isUserInteractionEnabled = false
         unreadIndicatorView.alpha = 0
         viewModel.didLoadLatest
             .receive(on: DispatchQueue.main)
@@ -52,6 +51,9 @@ extension HomeTimelineViewController {
                 self.unreadIndicatorView.translationY = .zero
             }
             .store(in: &disposeBag)
+        let unreadIndicatorViewTapGestureRecognizer = UITapGestureRecognizer.singleTapGestureRecognizer
+        unreadIndicatorViewTapGestureRecognizer.addTarget(self, action: #selector(HomeTimelineViewController.unreadIndicatorViewTapGestureRecognizerHandler(_:)))
+        unreadIndicatorView.addGestureRecognizer(unreadIndicatorViewTapGestureRecognizer)
 
         #if DEBUG
         navigationItem.rightBarButtonItem = debugActionBarButtonItem
@@ -140,6 +142,35 @@ extension HomeTimelineViewController {
             
             viewModel.loadItemCount += count
         }   // end Task
+    }
+    
+    @objc private func unreadIndicatorViewTapGestureRecognizerHandler(_ sender: UITapGestureRecognizer) {
+        logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public)")
+        
+        assert(sender.view === unreadIndicatorView)
+        guard unreadIndicatorView.alpha == 1 else { return }
+        
+        guard let viewModel = self.viewModel as? HomeTimelineViewModel,
+              let diffableDataSource = viewModel.diffableDataSource
+        else {
+            assertionFailure()
+            return
+        }
+        
+        guard let item = viewModel.latestUnreadStatusItem,
+              let indexPath = diffableDataSource.indexPath(for: item)
+        else { return }
+        
+        if let indexPathsForVisibleRows = tableView.indexPathsForVisibleRows,
+           !indexPathsForVisibleRows.isEmpty,
+           indexPathsForVisibleRows.contains(indexPath)
+        {
+            // do nothing when target index path visible
+            return
+        }
+        
+        tableView.scrollToRow(at: indexPath, at: .top, animated: true)
+        
     }
 }
 

--- a/TwidereX/Scene/Timeline/Home/HomeTimelineViewController.swift
+++ b/TwidereX/Scene/Timeline/Home/HomeTimelineViewController.swift
@@ -92,12 +92,7 @@ extension HomeTimelineViewController {
         .sink { [weak self] unreadItemCount, loadItemCount in
             guard let self = self else { return }
 
-            let count: Int
-            if loadItemCount > 0 {
-                count = loadItemCount
-            } else {
-                count = unreadItemCount
-            }
+            let count = max(0, loadItemCount) + max(0, unreadItemCount)
             self.unreadIndicatorView.count = count
             self.logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): update unread indicator count: \(count)")
             


### PR DESCRIPTION
The timeline auto-fetch reset the unread indicator count. Count two sources together to fix it.