### PR TITLE
Fix Twitter reply thread fetch logic broken issue

### DIFF
--- a/TwidereSDK/Sources/CoreDataStack/Entity/Twitter/TwitterStatus.swift
+++ b/TwidereSDK/Sources/CoreDataStack/Entity/Twitter/TwitterStatus.swift
@@ -62,7 +62,7 @@ final public class TwitterStatus: NSManagedObject {
     @NSManaged public private(set) var repost: TwitterStatus?
     // sourcery: autoGenerateRelationship
     @NSManaged public private(set) var quote: TwitterStatus?
-    // sourcery: autoUpdatableObject
+    // sourcery: autoGenerateRelationship, autoUpdatableObject
     @NSManaged public private(set) var replyTo: TwitterStatus?
     
     // one-to-many relationship
@@ -304,17 +304,20 @@ extension TwitterStatus: AutoGenerateRelationship {
     	public let author: TwitterUser
     	public let repost: TwitterStatus?
     	public let quote: TwitterStatus?
+    	public let replyTo: TwitterStatus?
 
     	public init(
     		poll: TwitterPoll?,
     		author: TwitterUser,
     		repost: TwitterStatus?,
-    		quote: TwitterStatus?
+    		quote: TwitterStatus?,
+    		replyTo: TwitterStatus?
     	) {
     		self.poll = poll
     		self.author = author
     		self.repost = repost
     		self.quote = quote
+    		self.replyTo = replyTo
     	}
     }
 
@@ -323,6 +326,7 @@ extension TwitterStatus: AutoGenerateRelationship {
     	self.author = relationship.author
     	self.repost = relationship.repost
     	self.quote = relationship.quote
+    	self.replyTo = relationship.replyTo
     }
     // sourcery:end
 }

--- a/TwidereSDK/Sources/TwidereCore/Persistence/Twitter/Persistence+TwitterStatus+V2.swift
+++ b/TwidereSDK/Sources/TwidereCore/Persistence/Twitter/Persistence+TwitterStatus+V2.swift
@@ -81,8 +81,24 @@ extension Persistence.TwitterStatus {
     ) -> PersistResult {
                 
         // build tree
-        // TODO: in reply to
-        // let replyTo = context.replyTo.flatMap { entity in … }
+
+        let replyTo = context.replyTo.flatMap { entity -> TwitterStatus in
+            let result = createOrMerge(
+                in: managedObjectContext,
+                context: PersistContextV2(
+                    entity: entity,
+                    repost: nil,
+                    quote: nil,
+                    replyTo: nil,
+                    dictionary: context.dictionary,
+                    me: context.me,
+                    statusCache: context.statusCache,
+                    userCache: context.userCache,
+                    networkDate: context.networkDate
+                )
+            )
+            return result.status
+        }
         
         let repost = context.repost.flatMap { entity -> TwitterStatus in
             let result = createOrMerge(
@@ -154,7 +170,8 @@ extension Persistence.TwitterStatus {
                 poll: poll,
                 author: author,
                 repost: repost,
-                quote: quote
+                quote: quote,
+                replyTo: replyTo
             )
             let status = create(in: managedObjectContext, context: context, relationship: relationship)
             context.statusCache?.dictionary[status.id] = status

--- a/TwidereSDK/Sources/TwidereCore/Persistence/Twitter/Persistence+TwitterStatus.swift
+++ b/TwidereSDK/Sources/TwidereCore/Persistence/Twitter/Persistence+TwitterStatus.swift
@@ -119,7 +119,8 @@ extension Persistence.TwitterStatus {
                 poll: nil,
                 author: author,
                 repost: repost,
-                quote: quote
+                quote: quote,
+                replyTo: nil
             )
             let status = create(in: managedObjectContext, context: context, relationship: relationship)
             return PersistResult(

--- a/TwidereX/Scene/Root/ContentSplitViewController.swift
+++ b/TwidereX/Scene/Root/ContentSplitViewController.swift
@@ -220,10 +220,10 @@ extension ContentSplitViewController: SidebarViewModelDelegate {
         default:
             viewModel.activeTab = tab
             if mainTabBarController.tabs.contains(tab) {
-                mainTabBarController.select(tab: tab)
+                mainTabBarController.select(tab: tab, isMainTabBarControllerActive: !isSecondaryTabBarControllerActive)
                 isSecondaryTabBarControllerActive = false
             } else if secondaryTabBarController.tabs.contains(tab) {
-                secondaryTabBarController.select(tab: tab)
+                secondaryTabBarController.select(tab: tab, isSecondaryTabBarControllerActive: isSecondaryTabBarControllerActive)
                 isSecondaryTabBarControllerActive = true
             } else {
                 assertionFailure()

--- a/TwidereX/Scene/Root/MainTab/MainTabBarController.swift
+++ b/TwidereX/Scene/Root/MainTab/MainTabBarController.swift
@@ -162,7 +162,7 @@ extension MainTabBarController {
 
 extension MainTabBarController {
 
-    func select(tab: TabBarItem) {
+    func select(tab: TabBarItem, isMainTabBarControllerActive: Bool = true) {
         let _index = tabBar.items?.firstIndex(where: { $0.tag == tab.tag })
         guard let index = _index else {
             return
@@ -174,7 +174,8 @@ extension MainTabBarController {
         }
         
         // check if selected and scroll it to top or pop to top
-        guard currentTab == tab,
+        guard isMainTabBarControllerActive,
+              currentTab == tab,
               let viewController = viewControllers?[safe: index],
               let navigationController = viewController as? UINavigationController
         else { return }

--- a/TwidereX/Scene/Root/SecondaryTab/SecondaryTabBarController.swift
+++ b/TwidereX/Scene/Root/SecondaryTab/SecondaryTabBarController.swift
@@ -61,7 +61,7 @@ extension SecondaryTabBarController {
 
 extension SecondaryTabBarController {
 
-    func select(tab: TabBarItem) {
+    func select(tab: TabBarItem, isSecondaryTabBarControllerActive: Bool = true) {
         let _index = tabBar.items?.firstIndex(where: { $0.tag == tab.tag })
         guard let index = _index else {
             return
@@ -73,7 +73,8 @@ extension SecondaryTabBarController {
         }
         
         // check if selected and scroll it to top
-        guard currentTab == tab,
+        guard isSecondaryTabBarControllerActive,
+              currentTab == tab,
               let viewController = viewControllers?[safe: index],
               let navigationController = viewController as? UINavigationController
         else { return }

--- a/TwidereX/Scene/StatusThread/Twitter/TwitterStatusThreadReplyViewModel+State.swift
+++ b/TwidereX/Scene/StatusThread/Twitter/TwitterStatusThreadReplyViewModel+State.swift
@@ -186,12 +186,12 @@ extension TwitterStatusThreadReplyViewModel.State {
                     assertionFailure()
                     return
                 }
-                await enter(state: nextState)
                 
-                // set nodes after state update
+                // set nodes before state update
                 self.logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): prepare reply nodes: \(nodes.debugDescription)")
                 await apply(nodes: nodes)
 
+                await enter(state: nextState)
                 
             }   // end Task
         }   // end didEnter


### PR DESCRIPTION
The new async-await mechanism causes the race condition hacking not works anymore. Remove the hack and fix the fetch issue. Now the Twitter thread should fetch the reply thread (unroll) and not only display the first reply.

And patch the #84 for active state precondition checking mississue.