### PR TITLE
Fix invisible tableView reload in background always scroll to top issue

### DIFF
--- a/TwidereX/Scene/Timeline/Base/List/ListTimelineViewController.swift
+++ b/TwidereX/Scene/Timeline/Base/List/ListTimelineViewController.swift
@@ -123,7 +123,12 @@ extension ListTimelineViewController {
         if !viewModel.isLoadingLatest {
             let now = Date()
             if let timestamp = viewModel.lastAutomaticFetchTimestamp {
-                if now.timeIntervalSince(timestamp) > 60 {
+                #if DEBUG
+                let throttle: TimeInterval = 1
+                #else
+                let throttle: TimeInterval = 60
+                #endif
+                if now.timeIntervalSince(timestamp) > throttle {
                     logger.log(level: .debug, "\((#file as NSString).lastPathComponent, privacy: .public)[\(#line, privacy: .public)], \(#function, privacy: .public): [Timeline] auto fetch lastest timeline…")
                     Task {
                         await _viewModel.loadLatest()

--- a/TwidereX/Scene/Timeline/Base/List/ListTimelineViewModel+Diffable.swift
+++ b/TwidereX/Scene/Timeline/Base/List/ListTimelineViewModel+Diffable.swift
@@ -37,8 +37,13 @@ extension ListTimelineViewModel {
     ) -> Difference<T>? {
         guard let sourceIndexPath = (tableView.indexPathsForVisibleRows ?? []).sorted().first else { return nil }
         let rectForSourceItemCell = tableView.rectForRow(at: sourceIndexPath)
-        let sourceDistanceToTableViewTopEdge = tableView.convert(rectForSourceItemCell, to: nil).origin.y - tableView.safeAreaInsets.top
-        
+        let sourceDistanceToTableViewTopEdge: CGFloat = {
+            if tableView.window != nil {
+                return tableView.convert(rectForSourceItemCell, to: nil).origin.y - tableView.safeAreaInsets.top
+            } else {
+                return rectForSourceItemCell.origin.y - tableView.contentOffset.y - tableView.safeAreaInsets.top
+            }
+        }()
         guard sourceIndexPath.section < oldSnapshot.numberOfSections,
               sourceIndexPath.row < oldSnapshot.numberOfItems(inSection: oldSnapshot.sectionIdentifiers[sourceIndexPath.section])
         else { return nil }


### PR DESCRIPTION
Calculate content frame in window manually when tableView is not displaying to avoid API returning a wrong value.