### PR TITLE
Fix mastodon direct message mention missing

### DIFF
--- a/TwidereSDK/Sources/TwidereCore/Model/Authentication/AuthenticationContext.swift
+++ b/TwidereSDK/Sources/TwidereCore/Model/Authentication/AuthenticationContext.swift
@@ -69,6 +69,15 @@ extension AuthenticationContext {
         }
     }
 }
+
+extension AuthenticationContext {
+    public var platform: Platform {
+        switch self {
+        case .twitter:      return .twitter
+        case .mastodon:     return .mastodon
+        }
+    }
+}
         
 public struct TwitterAuthenticationContext: Hashable {
     public let authenticationRecord: ManagedObjectRecord<TwitterAuthentication>

--- a/TwidereSDK/Sources/TwidereUI/Scene/ComposeContent/ComposeContentViewModel+MetaTextDelegate.swift
+++ b/TwidereSDK/Sources/TwidereUI/Scene/ComposeContent/ComposeContentViewModel+MetaTextDelegate.swift
@@ -24,10 +24,6 @@ extension ComposeContentViewModel: MetaTextDelegate {
         _ metaText: MetaText,
         processEditing textStorage: MetaTextStorage
     ) -> MetaContent? {
-        guard let author = self.author else {
-            return nil
-        }
-        
         let kind = MetaTextViewKind(rawValue: metaText.textView.tag) ?? .none
         
         switch kind {
@@ -39,7 +35,7 @@ extension ComposeContentViewModel: MetaTextDelegate {
             let textInput = textStorage.string
             self.content = textInput
             
-            switch author {
+            switch platform {
             case .twitter:
                 let content = TwitterContent(content: textInput)
                 let metaContent = TwitterMetaContent.convert(
@@ -56,6 +52,9 @@ extension ComposeContentViewModel: MetaTextDelegate {
                 )
                 let metaContent = MastodonMetaContent.convert(text: content)
                 return metaContent
+            case .none:
+                assertionFailure()
+                return nil
             }
             
         case .contentWarning:

--- a/TwidereSDK/Sources/TwidereUI/Scene/ComposeContent/ComposeContentViewModel.swift
+++ b/TwidereSDK/Sources/TwidereUI/Scene/ComposeContent/ComposeContentViewModel.swift
@@ -219,10 +219,19 @@ public final class ComposeContentViewModel: NSObject, ObservableObject {
                 
                 // set content text
                 var mentionAccts: [String] = []
-                mentionAccts.append("@" + status.author.acct)
+                let _authorUserIdentifier: MastodonUserIdentifier? = {
+                    switch configurationContext.authenticationService.activeAuthenticationContext?.userIdentifier {
+                    case .mastodon(let userIdentifier):     return userIdentifier
+                    default:                                return nil
+                    }
+                }()
+                if _authorUserIdentifier?.id != status.author.id {
+                    mentionAccts.append("@" + status.author.acct)
+                }
                 for mention in status.mentions {
                     let acct = "@" + mention.acct
                     guard !mentionAccts.contains(acct) else { continue }
+                    guard mention.id != _authorUserIdentifier?.id else { continue }
                     mentionAccts.append(acct)
                 }
                 for acct in mentionAccts {

--- a/TwidereSDK/Sources/TwidereUI/Scene/ComposeContent/ComposeContentViewModel.swift
+++ b/TwidereSDK/Sources/TwidereUI/Scene/ComposeContent/ComposeContentViewModel.swift
@@ -38,7 +38,8 @@ public final class ComposeContentViewModel: NSObject, ObservableObject {
     public let kind: Kind
     public let configurationContext: ConfigurationContext
     public let customEmojiPickerInputViewModel = CustomEmojiPickerInputView.ViewModel()
-
+    public let platform: Platform
+    
     // reply-to
     public private(set) var replyTo: StatusObject?
 
@@ -77,7 +78,7 @@ public final class ComposeContentViewModel: NSObject, ObservableObject {
     }
     @Published public var isContentWarningEditing = false
 
-    // avatar
+    // avatar (me)
     @Published public var author: UserObject?
         
     // mention (Twitter)
@@ -156,6 +157,7 @@ public final class ComposeContentViewModel: NSObject, ObservableObject {
     ) {
         self.kind = kind
         self.configurationContext = configurationContext
+        self.platform = configurationContext.authenticationService.activeAuthenticationContext?.platform ?? .none
         super.init()
         // end init
 
@@ -214,8 +216,23 @@ public final class ComposeContentViewModel: NSObject, ObservableObject {
                     isContentWarningComposing = true
                     contentWarning = spoilerText
                 }
+                
+                // set content text
+                var mentionAccts: [String] = []
+                mentionAccts.append("@" + status.author.acct)
+                for mention in status.mentions {
+                    let acct = "@" + mention.acct
+                    guard !mentionAccts.contains(acct) else { continue }
+                    mentionAccts.append(acct)
+                }
+                for acct in mentionAccts {
+                    UITextChecker.learnWord(acct)
+                }
+                content = mentionAccts.joined(separator: " ") + " "
             }
         }
+        
+        initialContent = content
         
         // bind text
         $content


### PR DESCRIPTION
The DM without explicitly mention cannot trigger mention notification on the remote. Add pre insert mention when reply mastodon status fixes it.